### PR TITLE
Add codira_mir/comptime crates, HIR comptime fold, and docs

### DIFF
--- a/.claude-flow/harness-active-policy.json
+++ b/.claude-flow/harness-active-policy.json
@@ -1,0 +1,14 @@
+{
+  "championId": "sha256:6141a8ea990c5063b77e090ae8f37f9c539d8aa8f58dcceb30f3a82f97e57319",
+  "provenanceTier": "oracle:test-exec",
+  "layer": "framework/node-cli",
+  "appliedAt": 1787216621388,
+  "previous": "",
+  "params": {
+    "alpha": 0.3,
+    "subjectWeight": 1,
+    "mmrLambda": 0.5,
+    "bodyWeight": 1.5,
+    "typePenaltyFactor": 0.5
+  }
+}

--- a/.claude-flow/neural/stats.json
+++ b/.claude-flow/neural/stats.json
@@ -1,0 +1,6 @@
+{
+  "trajectoriesRecorded": 23,
+  "patternsLearned": 21,
+  "signalsProcessed": 0,
+  "lastAdaptation": 1787220232718
+}

--- a/.claude-flow/policy/state.json
+++ b/.claude-flow/policy/state.json
@@ -1,0 +1,3652 @@
+{
+  "version": 1,
+  "mode": "legacy",
+  "rules": [],
+  "budgets": [],
+  "usage": [],
+  "approvals": [],
+  "receipts": [
+    {
+      "payload": {
+        "receiptId": "sha256:b067d8ea9aea96aece4445144ba870f68ca2508ce7357cc5349285c3468b3dbd",
+        "previousReceiptHash": null,
+        "sequence": 0,
+        "issuedAt": 1787216624066,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:3154ee493faa4fe631b87edb033a979abe3a2ba8db02b09197dc05a9b6cec990"
+            },
+            "now": 1787216624066
+          },
+          "requestId": "8ee5515f-c75a-42be-a3c0-19e56631ae12"
+        },
+        "decision": {
+          "requestId": "8ee5515f-c75a-42be-a3c0-19e56631ae12",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:a0e7190c80e624aa9e848c3196d49cab0f507e68a7fa2db351b6bcd055cfd6b6"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:7ac908f3bab357300fe1eeb96a219565939ff5921e895ab430d6f921a1170733",
+        "previousReceiptHash": "sha256:a0e7190c80e624aa9e848c3196d49cab0f507e68a7fa2db351b6bcd055cfd6b6",
+        "sequence": 1,
+        "issuedAt": 1787216630551,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:8ce46ee2b81f93da97c64f8530bb1a0f3ef55e398ef804fa30f99caa8128b59f"
+            },
+            "now": 1787216630551
+          },
+          "requestId": "41757304-440a-4958-88d3-4c1817a77be9"
+        },
+        "decision": {
+          "requestId": "41757304-440a-4958-88d3-4c1817a77be9",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:ecc151242d9ad1597fc847c3d2009e5daa51a0a7a77cac3087709b261b43e4b9"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:69bd4314c3bc6f88d728450c163fcfe354d2db139d405fbbdd7f6d649c957e9e",
+        "previousReceiptHash": "sha256:ecc151242d9ad1597fc847c3d2009e5daa51a0a7a77cac3087709b261b43e4b9",
+        "sequence": 2,
+        "issuedAt": 1787216718784,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:a6f721140974c2b7cf8670da4e3f716b906e04ff485498e089f74f0b52ed2299"
+            },
+            "now": 1787216718784
+          },
+          "requestId": "8956131a-8711-449f-8160-bc6de8d9789f"
+        },
+        "decision": {
+          "requestId": "8956131a-8711-449f-8160-bc6de8d9789f",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:c4e8455401718dcfa4fa9aef5108d8e4c8a4a103cfd6a9e6b4f2bb424a40c9f8"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:7c61bf9a60a7fbd07d4aa2d8f5a573db38f559307c08e82ca3fd64a8f54fad70",
+        "previousReceiptHash": "sha256:c4e8455401718dcfa4fa9aef5108d8e4c8a4a103cfd6a9e6b4f2bb424a40c9f8",
+        "sequence": 3,
+        "issuedAt": 1787216791314,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:fd85d9d7fddddbf4985f8cc43320b53aa09aea969d7a7dd3b935ce838b44390f"
+            },
+            "now": 1787216791314
+          },
+          "requestId": "feb91a8b-c4c0-4b43-9e94-e85647e78439"
+        },
+        "decision": {
+          "requestId": "feb91a8b-c4c0-4b43-9e94-e85647e78439",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:cec8d3af320fb7f9212d033bcf3f675bbfcb99c9e830b4b6608b73c27dd85932"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:a46b005f2896c2a3813cdb063eeac3cb94dc1712317b75b90d3f796ceb35d3d2",
+        "previousReceiptHash": "sha256:cec8d3af320fb7f9212d033bcf3f675bbfcb99c9e830b4b6608b73c27dd85932",
+        "sequence": 4,
+        "issuedAt": 1787216824458,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:72f1ea99225352b10296fead4116681fd143b208ce6291da842d4740ddb45eeb"
+            },
+            "now": 1787216824458
+          },
+          "requestId": "fe1f24e9-1490-4967-8817-88f31c367f2d"
+        },
+        "decision": {
+          "requestId": "fe1f24e9-1490-4967-8817-88f31c367f2d",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:063efab67e4557c64cd716ac4f8e56aa13a321d2fd9f41aa449755fa0a1a2056"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:49dfd7df45aa50d55a227f7a9855add67bc26b57397be84f5d5b1aaef5ef2682",
+        "previousReceiptHash": "sha256:063efab67e4557c64cd716ac4f8e56aa13a321d2fd9f41aa449755fa0a1a2056",
+        "sequence": 5,
+        "issuedAt": 1787216857846,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:33bd7f8aa8eded64b34830923f8ba9660217048c271ce86d08f12dd3958b8d86"
+            },
+            "now": 1787216857846
+          },
+          "requestId": "bdefc513-b348-4012-8c02-17edd4818738"
+        },
+        "decision": {
+          "requestId": "bdefc513-b348-4012-8c02-17edd4818738",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:c353b402faf389ffda1a37dbdcd6d1b7bab33988c49915cb16f1cc5f37052790"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:da022f98600971ff11baba7d72cbc0863b47793e7c271b24a12c959eba70fb35",
+        "previousReceiptHash": "sha256:c353b402faf389ffda1a37dbdcd6d1b7bab33988c49915cb16f1cc5f37052790",
+        "sequence": 6,
+        "issuedAt": 1787216868361,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:405021d0e7e9f5d33ae762516efebaf97fe8bd0cf06ff3895f0c46a92d939b02"
+            },
+            "now": 1787216868361
+          },
+          "requestId": "b47b6405-acdd-4daa-9b14-9aadf7846204"
+        },
+        "decision": {
+          "requestId": "b47b6405-acdd-4daa-9b14-9aadf7846204",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:f3e9afe04ae09cf0be03ae4fa3d3d677d78f321eba29ce26defa692c88b5aa26"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:9e511b25523f8738dbb9113b4bc37c7d2014d9c62234cdf0979e844d362d2712",
+        "previousReceiptHash": "sha256:f3e9afe04ae09cf0be03ae4fa3d3d677d78f321eba29ce26defa692c88b5aa26",
+        "sequence": 7,
+        "issuedAt": 1787216881167,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:4bdae0df2caa15c5d0043005e2cdf8f6584946ea143ea9b3fab68359c0bc549d"
+            },
+            "now": 1787216881167
+          },
+          "requestId": "8e2378a3-b7a6-4f9a-b633-889d149010ac"
+        },
+        "decision": {
+          "requestId": "8e2378a3-b7a6-4f9a-b633-889d149010ac",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:5661f760854ca34dbc678bc6ba32185a3482dbbd6f71536487bf95067a2218f9"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:f284552926333da747021278a421aa1742b93a771eb22655f2ed522f280ba6e0",
+        "previousReceiptHash": "sha256:5661f760854ca34dbc678bc6ba32185a3482dbbd6f71536487bf95067a2218f9",
+        "sequence": 8,
+        "issuedAt": 1787216910083,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:5535a825391710d0fc3caadfb157ca8925885b233ab427e6aca80ae43bbc98d6"
+            },
+            "now": 1787216910083
+          },
+          "requestId": "fef34981-2b1a-4159-844a-64023286fbd7"
+        },
+        "decision": {
+          "requestId": "fef34981-2b1a-4159-844a-64023286fbd7",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:6ea923da6437d9fa7514bb1a80cb45194fdcc8d956335fb8cd198ca4799239c2"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:bbd2d16ce0f8957c8675b8f4c048204210bc251d84b7bfdbc66be1049b5a654a",
+        "previousReceiptHash": "sha256:6ea923da6437d9fa7514bb1a80cb45194fdcc8d956335fb8cd198ca4799239c2",
+        "sequence": 9,
+        "issuedAt": 1787216927155,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:a81f30661066f87c49d77f2def6406c0ff82a3d2a1bccedd6fcb0d9175a62f7f"
+            },
+            "now": 1787216927155
+          },
+          "requestId": "cbfd17c3-8d0f-478f-9528-3399a7b7ea03"
+        },
+        "decision": {
+          "requestId": "cbfd17c3-8d0f-478f-9528-3399a7b7ea03",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:9ecf80c5e5171defdc61202f76025cfa6713d145283cc535788d451290c01517"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:eafb113f5092dc31631856c4fa8a9e2fba94f26fc7cbfcfd165b2e5d9e3cc711",
+        "previousReceiptHash": "sha256:9ecf80c5e5171defdc61202f76025cfa6713d145283cc535788d451290c01517",
+        "sequence": 10,
+        "issuedAt": 1787216979634,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:3cc104859a22ad28fb242774be0f4d2a3d751153edcf8d777412961e0c2a5630"
+            },
+            "now": 1787216979634
+          },
+          "requestId": "93d4a5a7-3732-4e15-91af-efafcb1c6dc7"
+        },
+        "decision": {
+          "requestId": "93d4a5a7-3732-4e15-91af-efafcb1c6dc7",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:4afd618cbbdd6d71002e433c30420a189a70581f1f567c0b471a9714a32a4abd"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:66d9ba00bfddd4683315096b91d33a4ea387a986716704a5b34a342dae94bc08",
+        "previousReceiptHash": "sha256:4afd618cbbdd6d71002e433c30420a189a70581f1f567c0b471a9714a32a4abd",
+        "sequence": 11,
+        "issuedAt": 1787217087768,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:cb6b9be4f183824672551464f77620770251459a5e6e3d79b712ecc4d6423ed7"
+            },
+            "now": 1787217087768
+          },
+          "requestId": "d68a92e8-b58f-439d-8523-892cf72136d4"
+        },
+        "decision": {
+          "requestId": "d68a92e8-b58f-439d-8523-892cf72136d4",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:7c7145a0d4c92ea23dcca94d052b0c8cd7ef9d23bd75f3bec230af0ef5852f11"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:926e6ea0eebeb35ef867371ffc7e0d351d6b356cf814a16ebc7c11d2cdb839aa",
+        "previousReceiptHash": "sha256:7c7145a0d4c92ea23dcca94d052b0c8cd7ef9d23bd75f3bec230af0ef5852f11",
+        "sequence": 12,
+        "issuedAt": 1787217095041,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:bd283bcc00ab7601a7cf684a3744621d857b8779c285a9e5eb2134845065a17e"
+            },
+            "now": 1787217095041
+          },
+          "requestId": "ffbe8b81-7239-477d-b082-73b8043907bd"
+        },
+        "decision": {
+          "requestId": "ffbe8b81-7239-477d-b082-73b8043907bd",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:c75ee8d5c7fdd254ad104339910b85afbc11b3df4ef082a89d08711e1edf232f"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:3356f539675ffc5b41fdb70841dc8f04dd41440d3969dff5c9e47f1a10e5def5",
+        "previousReceiptHash": "sha256:c75ee8d5c7fdd254ad104339910b85afbc11b3df4ef082a89d08711e1edf232f",
+        "sequence": 13,
+        "issuedAt": 1787217104117,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:f4a56df7f5c74ab68dd462dfc4b9cf571be8b11b1342d7dc9fbec5fc27b3de2d"
+            },
+            "now": 1787217104117
+          },
+          "requestId": "69b9478a-f915-4edc-bd4c-b83d4f9113fb"
+        },
+        "decision": {
+          "requestId": "69b9478a-f915-4edc-bd4c-b83d4f9113fb",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:eb0129411f79ed53d303fb9597bdca36cacb5afd2b1daf0ef2bb8f08c28b514e"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:aebeff23e5213d20060a9ec900ea3200ce30dfcf610f1a35d352e5409ed0df20",
+        "previousReceiptHash": "sha256:eb0129411f79ed53d303fb9597bdca36cacb5afd2b1daf0ef2bb8f08c28b514e",
+        "sequence": 14,
+        "issuedAt": 1787217114874,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:c6a2bf9e5868733543673f9e94f4ab709342e5e01b211a5957375a05fa699490"
+            },
+            "now": 1787217114874
+          },
+          "requestId": "cec335b9-f5e7-4035-8c90-04ac90e42b48"
+        },
+        "decision": {
+          "requestId": "cec335b9-f5e7-4035-8c90-04ac90e42b48",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:1b9bd69a6d198bfb056e27697c4e76bc6da981dd3dc20236b6b0116166346c18"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:3ff72f36082776c5e41b133e869a9629027a0dfa9fdc0087b1533169f146354f",
+        "previousReceiptHash": "sha256:1b9bd69a6d198bfb056e27697c4e76bc6da981dd3dc20236b6b0116166346c18",
+        "sequence": 15,
+        "issuedAt": 1787217122890,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:dc1116b900090aacf5ab7b5ca3ea3203148961c7f4c3bcb0851e9df9eea49ec0"
+            },
+            "now": 1787217122890
+          },
+          "requestId": "8e64946f-6abb-4669-adbe-3ef397decab6"
+        },
+        "decision": {
+          "requestId": "8e64946f-6abb-4669-adbe-3ef397decab6",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:aa6fb20e262f286a669cb8b486ee3b55e21904bb4af15cc36f651f251ebd8ba0"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:2a0db3c40a11bef8b1c07cb8e57308e2665fd9c4b35398444a5377762e80cfd7",
+        "previousReceiptHash": "sha256:aa6fb20e262f286a669cb8b486ee3b55e21904bb4af15cc36f651f251ebd8ba0",
+        "sequence": 16,
+        "issuedAt": 1787217131115,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:7055e2b873b564b68d2227b4c627e6fc82708624964f92a8babcd871ca0fe6f5"
+            },
+            "now": 1787217131115
+          },
+          "requestId": "572ecab9-6d82-43b3-aca3-0bfa9da9e619"
+        },
+        "decision": {
+          "requestId": "572ecab9-6d82-43b3-aca3-0bfa9da9e619",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:e3b3b778b14a2d3735b01436ae92cd4dc3bfbb4f9c291debe44b4b4b842aed35"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:832dacee50b12dbdaaf2ad51991cef471054a5c19bf865fc326bc5db4f0a8510",
+        "previousReceiptHash": "sha256:e3b3b778b14a2d3735b01436ae92cd4dc3bfbb4f9c291debe44b4b4b842aed35",
+        "sequence": 17,
+        "issuedAt": 1787217138937,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:79134f731af23a1b46db0ac988a5b16534328c50dec40a04732767b30dafdff2"
+            },
+            "now": 1787217138937
+          },
+          "requestId": "0fd1f545-d789-4b39-aaca-b69db0a74cc3"
+        },
+        "decision": {
+          "requestId": "0fd1f545-d789-4b39-aaca-b69db0a74cc3",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:5ea11cfaa34c84f8f3fb8368fe3b510ad07e109417bc01ead084c9a40e4bb2f7"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:1f8c088dbc67e46cd385fa45b2b1a416582e882f6d47f18a355c3db4b8eae022",
+        "previousReceiptHash": "sha256:5ea11cfaa34c84f8f3fb8368fe3b510ad07e109417bc01ead084c9a40e4bb2f7",
+        "sequence": 18,
+        "issuedAt": 1787217147878,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:d198126d420149e80aa06cba9e67dbeedb2fc0267cb92ae30cd1a03a444939be"
+            },
+            "now": 1787217147878
+          },
+          "requestId": "cc488cde-ad35-42b5-b8b8-447d68922361"
+        },
+        "decision": {
+          "requestId": "cc488cde-ad35-42b5-b8b8-447d68922361",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:db5ca42fe96d27e6c718116b5d3d5c3bf911528502a62dd45b79ede5ab3768d4"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:27d7340492081eee1c07c043c9fef7e546a878c886c607244a235407501b6868",
+        "previousReceiptHash": "sha256:db5ca42fe96d27e6c718116b5d3d5c3bf911528502a62dd45b79ede5ab3768d4",
+        "sequence": 19,
+        "issuedAt": 1787217155059,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:55874eaca97386d4bab2b82d3508db0630b84b8e896347132214b946739e6424"
+            },
+            "now": 1787217155059
+          },
+          "requestId": "9abe4583-4901-4827-a6a8-1c7f2b1ccb0f"
+        },
+        "decision": {
+          "requestId": "9abe4583-4901-4827-a6a8-1c7f2b1ccb0f",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:c3adf09b0a54712c43e1d475814242790da42db6227780c4227c0af89f728441"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:946d5ade6c04c6264d4ac6386749fcae0b1794b121610071cfd4bab165c1cbf3",
+        "previousReceiptHash": "sha256:c3adf09b0a54712c43e1d475814242790da42db6227780c4227c0af89f728441",
+        "sequence": 20,
+        "issuedAt": 1787217162969,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:04f7f0690e1518b4e27fe93181c4cd1277f7ec20755a9d59ddaa9056e7f19b79"
+            },
+            "now": 1787217162969
+          },
+          "requestId": "7a3411fd-ba4e-4984-961d-7d2c612690d8"
+        },
+        "decision": {
+          "requestId": "7a3411fd-ba4e-4984-961d-7d2c612690d8",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:64036b253a3c329090d7d990974893ffbd829f4abecdaacd9a0bbfa8c5f239c1"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:8778645ce0f31960a127bb48780baa6927caca74647799d3b4d1e88923ea5b0f",
+        "previousReceiptHash": "sha256:64036b253a3c329090d7d990974893ffbd829f4abecdaacd9a0bbfa8c5f239c1",
+        "sequence": 21,
+        "issuedAt": 1787217177743,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:a1dd3b36f558f05acb53bddc6b5597a4a3ffd1adaa860b9ac07952514bbc5445"
+            },
+            "now": 1787217177743
+          },
+          "requestId": "ae3d2120-6412-4408-af99-55b19a0b539e"
+        },
+        "decision": {
+          "requestId": "ae3d2120-6412-4408-af99-55b19a0b539e",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:3d69d2fdca3f7e7e4832ae237d6cd05279c10930b20a2e7a09f9934a6fec62ee"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:fbb9f8dd6c69fbd5bf75cf48da1511ef7b066113f7fe32ed1759a044509c9614",
+        "previousReceiptHash": "sha256:3d69d2fdca3f7e7e4832ae237d6cd05279c10930b20a2e7a09f9934a6fec62ee",
+        "sequence": 22,
+        "issuedAt": 1787217185976,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:cd3c7755b380f1048c9cc793d21831e600cae53e56539a8385edeeb74081d498"
+            },
+            "now": 1787217185976
+          },
+          "requestId": "d4322283-8e1a-4eb3-bf16-6845c248bbba"
+        },
+        "decision": {
+          "requestId": "d4322283-8e1a-4eb3-bf16-6845c248bbba",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:e24db4068e47894ba779c9d4abf4f5855460ecd6283211e56665267abe2f4494"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:e102ca990988595cb748de62e688ba648a2be3419eaaaad8cda444865f0615f3",
+        "previousReceiptHash": "sha256:e24db4068e47894ba779c9d4abf4f5855460ecd6283211e56665267abe2f4494",
+        "sequence": 23,
+        "issuedAt": 1787217193856,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:d433788385f606a7b61378b555a65d735f60cbaa37425b18ea11a8bc9d4ea749"
+            },
+            "now": 1787217193856
+          },
+          "requestId": "21dcf55e-0e0c-484b-8391-d3da5b74266a"
+        },
+        "decision": {
+          "requestId": "21dcf55e-0e0c-484b-8391-d3da5b74266a",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:84aae0f9517d915119950432d02e4a663c47cf2bb07d04b6d53b44cab547b412"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:0458ddfc35de433cb4ef48b2ab1a9b71e6af41ea2dab763e0fc219fe7a0805a4",
+        "previousReceiptHash": "sha256:84aae0f9517d915119950432d02e4a663c47cf2bb07d04b6d53b44cab547b412",
+        "sequence": 24,
+        "issuedAt": 1787217245244,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:8d445e1863d6cd289dda55b8b5536a0b859fc79e74814d762b93eac1b221077d"
+            },
+            "now": 1787217245244
+          },
+          "requestId": "25c6a376-c970-4b22-bf41-3b3094e43c9e"
+        },
+        "decision": {
+          "requestId": "25c6a376-c970-4b22-bf41-3b3094e43c9e",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:5827a5d557221f67361b518734a0ba2208e69c80b9bd9b4d528ce513b3d34317"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:6281307eae84cf535c4da94f4ce455e05113db8e03cb9a03fd23547c8c8c5b61",
+        "previousReceiptHash": "sha256:5827a5d557221f67361b518734a0ba2208e69c80b9bd9b4d528ce513b3d34317",
+        "sequence": 25,
+        "issuedAt": 1787218388010,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:16b178f74c8c157e07ef2e8cb15285a3cb44b85664745ff2419cb8aabc0aa306"
+            },
+            "now": 1787218388010
+          },
+          "requestId": "ad66c8c0-6e32-4c08-8b54-e1b34f2fd4c7"
+        },
+        "decision": {
+          "requestId": "ad66c8c0-6e32-4c08-8b54-e1b34f2fd4c7",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:300deaf7e18f2a11c6ea56795b55e194c005a39ef2f9252d1372935ea0268a0b"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:37d2b84b07b1bcf696d05a67d77be0dc43bf0dabb69fe63a1760f9c7e7ae21c5",
+        "previousReceiptHash": "sha256:300deaf7e18f2a11c6ea56795b55e194c005a39ef2f9252d1372935ea0268a0b",
+        "sequence": 26,
+        "issuedAt": 1787218406087,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:314ad1f0871f0b2a44ae55642cbad37c7d93c608048006779e4023c3fbff6c61"
+            },
+            "now": 1787218406087
+          },
+          "requestId": "f3e07156-93bd-4277-bcaa-6a587ab3d18e"
+        },
+        "decision": {
+          "requestId": "f3e07156-93bd-4277-bcaa-6a587ab3d18e",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:d49d7448a99371c47f7629890e17bf0a66bbc8ec6120b945e94c743406b91715"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:34bba3dec152977ac30ccb70860fd63c2d5e0a4c9f8a370b167fc27855258bd6",
+        "previousReceiptHash": "sha256:d49d7448a99371c47f7629890e17bf0a66bbc8ec6120b945e94c743406b91715",
+        "sequence": 27,
+        "issuedAt": 1787218420840,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:e88c29e5416772336ecfe1b5b66697a909ec32310d0ccbc8fa6c43734d185fae"
+            },
+            "now": 1787218420840
+          },
+          "requestId": "e2f12b2a-510c-45e5-881a-36143a9d33c1"
+        },
+        "decision": {
+          "requestId": "e2f12b2a-510c-45e5-881a-36143a9d33c1",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:e9aa08a471a405c22ace6da66f0ef59cea207f702528704b8758a009d32b14af"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:9e7611a79e579f6abbf6f0fec1faf7c64df1262e3e45eddcc73ec24c2f49996f",
+        "previousReceiptHash": "sha256:e9aa08a471a405c22ace6da66f0ef59cea207f702528704b8758a009d32b14af",
+        "sequence": 28,
+        "issuedAt": 1787218563539,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:d060a70ba4773b13ded19355f696bfec99df37e78e277f9f79e34a1031ed7051"
+            },
+            "now": 1787218563539
+          },
+          "requestId": "a28420b3-6d79-414a-8c36-7f0e17e7f7f7"
+        },
+        "decision": {
+          "requestId": "a28420b3-6d79-414a-8c36-7f0e17e7f7f7",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:c627bc1222e026bba9aacf248f6e327397a553789a469c0ec8b14dfb22670907"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:f678c4f7713724c4fabddf491d7fa6ffe8959c00720a6808eea6a42f05849aeb",
+        "previousReceiptHash": "sha256:c627bc1222e026bba9aacf248f6e327397a553789a469c0ec8b14dfb22670907",
+        "sequence": 29,
+        "issuedAt": 1787218576052,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:b0b454d2be31b964c06e7d51f05a748ea67b582edfa5fc91c701e198acf0d6ae"
+            },
+            "now": 1787218576052
+          },
+          "requestId": "2b1b30d4-be23-413b-82e5-bde59b7b40ae"
+        },
+        "decision": {
+          "requestId": "2b1b30d4-be23-413b-82e5-bde59b7b40ae",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:35dd2f7561919b534b82eadbc1cf62a20e7bf3263bf80223373d4b3d07bec2d0"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:925a07143f36b8de53539df1db9ab9773430b18e94d1d081d3bbfd9a943aa674",
+        "previousReceiptHash": "sha256:35dd2f7561919b534b82eadbc1cf62a20e7bf3263bf80223373d4b3d07bec2d0",
+        "sequence": 30,
+        "issuedAt": 1787218889092,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:39df9c4afd017c6457107cfc3394f578e7d7ce527d5da013f8b616c0b4e0a0a1"
+            },
+            "now": 1787218889092
+          },
+          "requestId": "3f73debd-7490-4d49-826e-74e0d0c01ccb"
+        },
+        "decision": {
+          "requestId": "3f73debd-7490-4d49-826e-74e0d0c01ccb",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:b387657e94fed6aeb7d427c53c6cf3ccfc1b79b7cd5b04b49d2d07662cbc5e8b"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:2c568c66c9bf87d7c0c64218a16b716d740d9e33f54f386b229786422f0df7f1",
+        "previousReceiptHash": "sha256:b387657e94fed6aeb7d427c53c6cf3ccfc1b79b7cd5b04b49d2d07662cbc5e8b",
+        "sequence": 31,
+        "issuedAt": 1787218899124,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:8f08fc0788f5ecc487fb93a0204978d997935d2fbab24207005e3001561310b3"
+            },
+            "now": 1787218899124
+          },
+          "requestId": "65cacec4-f6d4-46b1-8735-dcbdfad5a7a2"
+        },
+        "decision": {
+          "requestId": "65cacec4-f6d4-46b1-8735-dcbdfad5a7a2",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:05e5354b4be8fbbfce10305db3e03c5c722e7ae9e514ee8ea44cb0ca2b795b13"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:f81be8d0129dd37c0fe5bb28cf5f3c42e9503f78c8c9c1b579bdc436f97000e1",
+        "previousReceiptHash": "sha256:05e5354b4be8fbbfce10305db3e03c5c722e7ae9e514ee8ea44cb0ca2b795b13",
+        "sequence": 32,
+        "issuedAt": 1787218929030,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:c5e5e22cec2f2e83802c0a0cbb569cda0e6b6620fd84024e7774d6b96ee07f9f"
+            },
+            "now": 1787218929030
+          },
+          "requestId": "b87007e6-8232-4812-8861-a59403fcd06e"
+        },
+        "decision": {
+          "requestId": "b87007e6-8232-4812-8861-a59403fcd06e",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:17e15b866ab9874f7b2122c026856f2c3efefb5894780c75c8c9a285c2c9a2c2"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:093e7ffaa7bad553ab51679ae1270f7de2018142b7ebbb26396b7663c22f196c",
+        "previousReceiptHash": "sha256:17e15b866ab9874f7b2122c026856f2c3efefb5894780c75c8c9a285c2c9a2c2",
+        "sequence": 33,
+        "issuedAt": 1787218951429,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:e64ffdc873c0b1673fe23437767ba20560140c3089879be43235fb533c7f8b62"
+            },
+            "now": 1787218951429
+          },
+          "requestId": "6c220ff5-8563-4293-a2a2-4c7e016c3793"
+        },
+        "decision": {
+          "requestId": "6c220ff5-8563-4293-a2a2-4c7e016c3793",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:e4271d07179be307b9335ba0c1762989a6046a98e75bd487d0bacf9f8a43975e"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:009a806f7e1d562a750a6bc75e08d29314f2ff3bd82f0bd5aa03d4ff98490887",
+        "previousReceiptHash": "sha256:e4271d07179be307b9335ba0c1762989a6046a98e75bd487d0bacf9f8a43975e",
+        "sequence": 34,
+        "issuedAt": 1787218962937,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:73f84a52dd517be8d8544940c7625c37098f73c6d9cf26b16cfe1ebffe298c96"
+            },
+            "now": 1787218962937
+          },
+          "requestId": "b955d9d1-85ae-4a9c-9385-15d24fece336"
+        },
+        "decision": {
+          "requestId": "b955d9d1-85ae-4a9c-9385-15d24fece336",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:5100ed290ba0a95b52b6ce3f6c1f85e27b2e1db4eb49f5e7220b2356efa3a794"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:3823e7a8663acf4707bf51e2f362f3b405c00a4879c849061b9a842fdf00c448",
+        "previousReceiptHash": "sha256:5100ed290ba0a95b52b6ce3f6c1f85e27b2e1db4eb49f5e7220b2356efa3a794",
+        "sequence": 35,
+        "issuedAt": 1787218981519,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:22bc20afc21af07907257d9c90e4798e0c648bfc12e8f7e12502eccbb39f546e"
+            },
+            "now": 1787218981519
+          },
+          "requestId": "916f91c6-db03-4161-8b37-a4c46f1417ae"
+        },
+        "decision": {
+          "requestId": "916f91c6-db03-4161-8b37-a4c46f1417ae",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:9b57ba2204e3eed168aef6f46433743fb8031c3e61d5162e8007c084eb03bf8c"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:1a97816a9d74ad864899ece27c0508f6dd2b1e21241fd9486eff9d29c91783bd",
+        "previousReceiptHash": "sha256:9b57ba2204e3eed168aef6f46433743fb8031c3e61d5162e8007c084eb03bf8c",
+        "sequence": 36,
+        "issuedAt": 1787218997577,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:4785dd0f8584c92d858ead884fed412fc0119c9076cb694a81045f43505c2b10"
+            },
+            "now": 1787218997577
+          },
+          "requestId": "6e0eaedf-bf49-40f7-a972-8541be5f2fe6"
+        },
+        "decision": {
+          "requestId": "6e0eaedf-bf49-40f7-a972-8541be5f2fe6",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:5d1b3cd4448c7e14b92f7e01182e620afedbe83badbab9165f97445eb5b79ed9"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:e6d649a2ab9d84e40732caf9bc59676a1e683539088032e601f4fd5dcda7e777",
+        "previousReceiptHash": "sha256:5d1b3cd4448c7e14b92f7e01182e620afedbe83badbab9165f97445eb5b79ed9",
+        "sequence": 37,
+        "issuedAt": 1787219015236,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:3753675e52e16008ac4137a266a23a52839196754a4f7c4d3d5cb8a3a1065f2d"
+            },
+            "now": 1787219015236
+          },
+          "requestId": "3d0e3b89-2045-4881-a5a0-2d0ca8494fe2"
+        },
+        "decision": {
+          "requestId": "3d0e3b89-2045-4881-a5a0-2d0ca8494fe2",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:b1a57fe1b6d4af0be18f130fc480143091c261a248766e922cffa4332265b693"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:d6da7f4ad4f0ad94de907e90fa5b71615a09195a447ffd490e4c87fe718e60b3",
+        "previousReceiptHash": "sha256:b1a57fe1b6d4af0be18f130fc480143091c261a248766e922cffa4332265b693",
+        "sequence": 38,
+        "issuedAt": 1787219023103,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:5e0c2ab118edfbdb833548185043160f70a6ac714fec883c0dc049bd33286edf"
+            },
+            "now": 1787219023103
+          },
+          "requestId": "8ed8522a-0a5b-421a-8d5b-6b7c69d3b1a3"
+        },
+        "decision": {
+          "requestId": "8ed8522a-0a5b-421a-8d5b-6b7c69d3b1a3",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:d6237f9222c011abea4a796f5d9ae2c6df64f93d880be30072a430c6c4addcc5"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:9452242020918e11e7a51950a8caa1ae36701dfacabe03dc4e8261eebed5e9f9",
+        "previousReceiptHash": "sha256:d6237f9222c011abea4a796f5d9ae2c6df64f93d880be30072a430c6c4addcc5",
+        "sequence": 39,
+        "issuedAt": 1787219031649,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:437f4d445b38737caa5ee2d6e1396245e1c2d28d965793a29a9876eefd953faa"
+            },
+            "now": 1787219031649
+          },
+          "requestId": "9c425214-d231-4542-9c64-a13acc4c35c7"
+        },
+        "decision": {
+          "requestId": "9c425214-d231-4542-9c64-a13acc4c35c7",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:7b793554e9d8a6278e482d8788cdb73273aa26fedb3f25a7d5cdccf518bf460c"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:50afb95f21b10cd2c7a0107235016c72f7561d488a60dea76ab0777ccb4e085b",
+        "previousReceiptHash": "sha256:7b793554e9d8a6278e482d8788cdb73273aa26fedb3f25a7d5cdccf518bf460c",
+        "sequence": 40,
+        "issuedAt": 1787219042428,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:af42e5e9b10412442e75d0c9da9027bbef68e9682e53b24c2a535b57a8d85456"
+            },
+            "now": 1787219042428
+          },
+          "requestId": "a22a9181-fae6-4316-a500-486c117013e9"
+        },
+        "decision": {
+          "requestId": "a22a9181-fae6-4316-a500-486c117013e9",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:376655d6bf4221d95422b2a86bcedbef7b8d00fd54d2c2bbae0a6bc926622c26"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:bde0c62648e3984a3a240c43b6f8e5403c82f4ade270c13fb3abcb22b7453394",
+        "previousReceiptHash": "sha256:376655d6bf4221d95422b2a86bcedbef7b8d00fd54d2c2bbae0a6bc926622c26",
+        "sequence": 41,
+        "issuedAt": 1787219049714,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:963e7890cde697c0a86b983aa383f6ec7f7c0e61fb320a3fb9625aa5c1d3cfeb"
+            },
+            "now": 1787219049714
+          },
+          "requestId": "4c432b70-d834-4e9e-9d1d-10f14090b8dc"
+        },
+        "decision": {
+          "requestId": "4c432b70-d834-4e9e-9d1d-10f14090b8dc",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:bcdc5fc06780b984bc6585fe42071d18fc221f01295beef6d4ba292bf289face"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:3db5e2fa8aed572b8ba513a1f9bc9edadb6e70a1f6c0bfd2f0a1d24692b02196",
+        "previousReceiptHash": "sha256:bcdc5fc06780b984bc6585fe42071d18fc221f01295beef6d4ba292bf289face",
+        "sequence": 42,
+        "issuedAt": 1787219058953,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:bc21dee7695fb42359b0d6e66e76a3538abd1cc939a557db4bceee558f1850cd"
+            },
+            "now": 1787219058953
+          },
+          "requestId": "2b5b0667-9f02-4b73-a6a1-5a4fc68c1fbe"
+        },
+        "decision": {
+          "requestId": "2b5b0667-9f02-4b73-a6a1-5a4fc68c1fbe",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:02651596d43bf70886418afaf3c48a9121ac6199aec6e1eb751028df8bd1c43c"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:c619277380d8cd25ed39288616179a61eebae57e2e7dd05c9d0945baea626ca9",
+        "previousReceiptHash": "sha256:02651596d43bf70886418afaf3c48a9121ac6199aec6e1eb751028df8bd1c43c",
+        "sequence": 43,
+        "issuedAt": 1787219067150,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:e48b8794152ff43a2ba8a43a1731486d0581b99fbb7c23bcfb94af4ccf8323a8"
+            },
+            "now": 1787219067150
+          },
+          "requestId": "fa55f6d8-e522-4efa-8d48-36ee37c6aafc"
+        },
+        "decision": {
+          "requestId": "fa55f6d8-e522-4efa-8d48-36ee37c6aafc",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:a5c9fd606e814d1604dde7b9bd1fc5fd92a32a4771b1e0c5e75b20a43f86a2b1"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:69b6ae46e5b435be7e22dd686cb07ae1c327197ee76f9706b4c50791e7af8a8c",
+        "previousReceiptHash": "sha256:a5c9fd606e814d1604dde7b9bd1fc5fd92a32a4771b1e0c5e75b20a43f86a2b1",
+        "sequence": 44,
+        "issuedAt": 1787219074725,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:ca480c6d7bad7f1a6bcf627fb0ffcaf354aa32b06c7597888b4823c112789d4e"
+            },
+            "now": 1787219074725
+          },
+          "requestId": "526a3f15-11bd-4077-bf4a-ab1ad27a4ab4"
+        },
+        "decision": {
+          "requestId": "526a3f15-11bd-4077-bf4a-ab1ad27a4ab4",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:b718198f2b4fb1b25416ebdb11917bfd7dcce6b1ca44f95333b54d28b08b4de8"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:c53a9b0d38f380bc72cb0672c2f54b80fb9b1ac855eafad0f7511a85273c63c2",
+        "previousReceiptHash": "sha256:b718198f2b4fb1b25416ebdb11917bfd7dcce6b1ca44f95333b54d28b08b4de8",
+        "sequence": 45,
+        "issuedAt": 1787219087461,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:345c76d8f1ebcbf91435d61c8314e35fb9ed011b30b5ffb69aa196396873ccaf"
+            },
+            "now": 1787219087461
+          },
+          "requestId": "86338a70-39a0-4624-a7d4-258b5fc31096"
+        },
+        "decision": {
+          "requestId": "86338a70-39a0-4624-a7d4-258b5fc31096",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:a53f7c92c26a4afa6fcdad9d8a6b44bd6cdec6c52914ba02d39b4cc95427a511"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:60ea00c6e85b79cebc57e9b8b6eeaa97bfb4c28e37c39182359c2d12ea26fc9c",
+        "previousReceiptHash": "sha256:a53f7c92c26a4afa6fcdad9d8a6b44bd6cdec6c52914ba02d39b4cc95427a511",
+        "sequence": 46,
+        "issuedAt": 1787219100823,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:02617528d09fa99a2df6c6535dc948f7e01a276a32df095e28749ff7cfe0ef3d"
+            },
+            "now": 1787219100823
+          },
+          "requestId": "33b739f9-1a87-4228-979d-290fc8ab6a19"
+        },
+        "decision": {
+          "requestId": "33b739f9-1a87-4228-979d-290fc8ab6a19",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:b8e5287c407fc4fe516c9527f145a51ac7e7b53cf5ceeafd1582bfd508f91e9a"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:270442a2b7473026e014ed2f88a8620dd12fce0415741e37b8891903c171f637",
+        "previousReceiptHash": "sha256:b8e5287c407fc4fe516c9527f145a51ac7e7b53cf5ceeafd1582bfd508f91e9a",
+        "sequence": 47,
+        "issuedAt": 1787219284756,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:466d7754a14cb03f674e58171913bdc985857ff8db41e8cbce9df4224b236684"
+            },
+            "now": 1787219284756
+          },
+          "requestId": "cba05408-2200-49d2-b1a5-6b7cdda1a91a"
+        },
+        "decision": {
+          "requestId": "cba05408-2200-49d2-b1a5-6b7cdda1a91a",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:aecaa84c2e04c0553c0bdba4afa529acd6d44c2b63f060eb3176eedaa278a00a"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:8992546d8db1adc6244b788b2f3114c01d15e6d48612db996ecc992cc6bd14be",
+        "previousReceiptHash": "sha256:aecaa84c2e04c0553c0bdba4afa529acd6d44c2b63f060eb3176eedaa278a00a",
+        "sequence": 48,
+        "issuedAt": 1787219292884,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:e944b259e73c213d91de6e91ed5f532cfce99f9959733535e0257b19e2919319"
+            },
+            "now": 1787219292884
+          },
+          "requestId": "58d20e42-7056-4ea7-964d-291166861e58"
+        },
+        "decision": {
+          "requestId": "58d20e42-7056-4ea7-964d-291166861e58",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:8d582a51b77d635e07f5e876fc577f994ea28844fc80645cd52734cdf2d05983"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:792fdd58569309ac452d6b8eb83c65dac80f80edd13e73f3902898a615f3fbf7",
+        "previousReceiptHash": "sha256:8d582a51b77d635e07f5e876fc577f994ea28844fc80645cd52734cdf2d05983",
+        "sequence": 49,
+        "issuedAt": 1787219326462,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:d8ba0822b7b72bc2e39ba375346b017c5664b1687c75fe513a53025b9bb0e00a"
+            },
+            "now": 1787219326462
+          },
+          "requestId": "3fa73330-1df6-4962-8ebc-fffcf21a32f9"
+        },
+        "decision": {
+          "requestId": "3fa73330-1df6-4962-8ebc-fffcf21a32f9",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:f44efa655d165a7687259cd166676777235bc08575056463eeb1d55b7d70be6f"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:5e2d2fb10b4ac23411b41812c01082d6d0a1bffeec61abd00a6845b03d45eb44",
+        "previousReceiptHash": "sha256:f44efa655d165a7687259cd166676777235bc08575056463eeb1d55b7d70be6f",
+        "sequence": 50,
+        "issuedAt": 1787219340048,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:c0f72892a77e770d0902684278ce1fec364a9b0a4894cd4fff494af349c50deb"
+            },
+            "now": 1787219340048
+          },
+          "requestId": "614f3ae6-bcfe-492e-8388-2105632eb782"
+        },
+        "decision": {
+          "requestId": "614f3ae6-bcfe-492e-8388-2105632eb782",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:c0069d3b19ce1a2856fc5f0638720e0de63ba07b508aa2cfd7c990e3be77782e"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:61fb206f79a08af6edbb530f8d5c298bc63422ee0f39f1b85100bcf2d2157b02",
+        "previousReceiptHash": "sha256:c0069d3b19ce1a2856fc5f0638720e0de63ba07b508aa2cfd7c990e3be77782e",
+        "sequence": 51,
+        "issuedAt": 1787219351560,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:001dd27210a93c038bc7dc5dbadccc139d93aee740c6c5345004564ea1917fc7"
+            },
+            "now": 1787219351560
+          },
+          "requestId": "e2be1d28-5fab-4c33-9874-e55b9f370f59"
+        },
+        "decision": {
+          "requestId": "e2be1d28-5fab-4c33-9874-e55b9f370f59",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:49bac89a894755ac6bd445fe9f4dfd50abf921b939ff3b99fcca3d8b459f771d"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:0d52eda2de3c760f9816d1482a0d245a5922a5bd3dd507f1f9ab5d0b1af98fa3",
+        "previousReceiptHash": "sha256:49bac89a894755ac6bd445fe9f4dfd50abf921b939ff3b99fcca3d8b459f771d",
+        "sequence": 52,
+        "issuedAt": 1787219369534,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:a71f5d2f7c3dc06f045418059db102caa6c07d59165f8927351c0b8dee4715fc"
+            },
+            "now": 1787219369534
+          },
+          "requestId": "fbd38576-b084-49fe-9e7c-c83d65a0ee86"
+        },
+        "decision": {
+          "requestId": "fbd38576-b084-49fe-9e7c-c83d65a0ee86",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:988563e34bf75ee8e935e724a5e2f3d6911367b0d9ea3c3f2c30e728685c508c"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:801d908849306994941afe5281fbdc3648558ed604151bbc3ab7fe434e0d1a61",
+        "previousReceiptHash": "sha256:988563e34bf75ee8e935e724a5e2f3d6911367b0d9ea3c3f2c30e728685c508c",
+        "sequence": 53,
+        "issuedAt": 1787219383937,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:3f85e32cfe42299f91d370a59e88f294b89f2806137582b2b5f419f97634e9f3"
+            },
+            "now": 1787219383937
+          },
+          "requestId": "db1c4e58-5dfc-463c-afbc-41ac59b84f6f"
+        },
+        "decision": {
+          "requestId": "db1c4e58-5dfc-463c-afbc-41ac59b84f6f",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:808f85232278b0d9a946588aa7c7be0783ebdd5623a425bd5b39e67eb24accfe"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:3301ba280cee436da5151c0c60bb44d3669bb096dda637c0ee0c9c8a81cff23e",
+        "previousReceiptHash": "sha256:808f85232278b0d9a946588aa7c7be0783ebdd5623a425bd5b39e67eb24accfe",
+        "sequence": 54,
+        "issuedAt": 1787219414729,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:7dbd2255dfa62433cac301220625365440423ef6b1f7f0faab42e8db0a3f2b69"
+            },
+            "now": 1787219414729
+          },
+          "requestId": "1bf750ee-9c82-4520-82b1-d3ed5f2f71c0"
+        },
+        "decision": {
+          "requestId": "1bf750ee-9c82-4520-82b1-d3ed5f2f71c0",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:ee7d6d671c1141f04e522e4d7d67bf2b799e14db4bf806c7334e7f9238f2ddfe"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:3e730a21603a1d734ae78adcc11db6e7019bf8e9a4a28e763f20d8ba35579834",
+        "previousReceiptHash": "sha256:ee7d6d671c1141f04e522e4d7d67bf2b799e14db4bf806c7334e7f9238f2ddfe",
+        "sequence": 55,
+        "issuedAt": 1787219423048,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:bafa3382e3d5d54e697302f7ad20cf86bfb85666c46c2327210ddce4840a036f"
+            },
+            "now": 1787219423048
+          },
+          "requestId": "3ce22969-4128-41e6-97ba-832d04a487e0"
+        },
+        "decision": {
+          "requestId": "3ce22969-4128-41e6-97ba-832d04a487e0",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:f2935d3e8c4ef783d1bb0c61080dd1b7a99e9f4e8629dda5d68750fcab24048f"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:49c1d2fa2520dd6734f591bfe0161812f05bce05f29d9a0b1ebbe31ecc15e52d",
+        "previousReceiptHash": "sha256:f2935d3e8c4ef783d1bb0c61080dd1b7a99e9f4e8629dda5d68750fcab24048f",
+        "sequence": 56,
+        "issuedAt": 1787219446221,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:87f9f6076506fa22a2941a631a755c21fd26ae96abc81e0785eaa187b0c70ada"
+            },
+            "now": 1787219446221
+          },
+          "requestId": "834cf429-7f83-414c-9430-e25c964f5131"
+        },
+        "decision": {
+          "requestId": "834cf429-7f83-414c-9430-e25c964f5131",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:246c1ac462f6b3e7d518bc259a5225e604b5d6266ac8afd8ce976be7b124d967"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:b1844abdfa8980dfcb1abb835012b590227623a24222a945507b98d816e07511",
+        "previousReceiptHash": "sha256:246c1ac462f6b3e7d518bc259a5225e604b5d6266ac8afd8ce976be7b124d967",
+        "sequence": 57,
+        "issuedAt": 1787219463224,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:9d529b43dbc4837fcabe0990839314274aec613412e2da9218e7c15726573b61"
+            },
+            "now": 1787219463224
+          },
+          "requestId": "5b88ed80-6762-465a-97d8-5939edcef6f4"
+        },
+        "decision": {
+          "requestId": "5b88ed80-6762-465a-97d8-5939edcef6f4",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:dbe4f2f4264e7c4a2ab29ab271cccc2312f2474c63485ca3c94415835b046e8f"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:77e6c8d00844dae1d641fff6f9ce24b9f1217a668122da69bcd47c0fdd453a2d",
+        "previousReceiptHash": "sha256:dbe4f2f4264e7c4a2ab29ab271cccc2312f2474c63485ca3c94415835b046e8f",
+        "sequence": 58,
+        "issuedAt": 1787219488831,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:6e1bcb37ac140ddbb17de9b96cfe6681a4e4afff5909da4b27127c956f49aaa0"
+            },
+            "now": 1787219488831
+          },
+          "requestId": "b79e3b48-0d0b-4137-a016-f2d420a711bd"
+        },
+        "decision": {
+          "requestId": "b79e3b48-0d0b-4137-a016-f2d420a711bd",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:e6af6bcac75759dcfe77713d8d15196b33fb217cdb7a94db7053e59ddab01da3"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:1b1863f832f11db06bcafea010a27e65bea941432439be923edc8aae63ad25ad",
+        "previousReceiptHash": "sha256:e6af6bcac75759dcfe77713d8d15196b33fb217cdb7a94db7053e59ddab01da3",
+        "sequence": 59,
+        "issuedAt": 1787219506192,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:e0445aa40750b51956f2a7cf5cf56387a68de61dad4f2732a4c0eff94e2c524c"
+            },
+            "now": 1787219506192
+          },
+          "requestId": "37479f9a-0929-4310-9f1f-b59e88dc2029"
+        },
+        "decision": {
+          "requestId": "37479f9a-0929-4310-9f1f-b59e88dc2029",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:41e9488e35b1cdf162fc8bb83c50f6d4016cc07c1d468d32772ee5b795967901"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:fdad7e49028678d8fec585fcaa2e1152ccb315dcbbb5b34cf370341473e6901b",
+        "previousReceiptHash": "sha256:41e9488e35b1cdf162fc8bb83c50f6d4016cc07c1d468d32772ee5b795967901",
+        "sequence": 60,
+        "issuedAt": 1787219514400,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:3d42f9f0de8e6d596c2269ca1ccbfd0abf25fb787126d82bdbe72d8b71a21ec7"
+            },
+            "now": 1787219514400
+          },
+          "requestId": "5b0e6511-bb2d-4d33-814d-b2cdd92f17b7"
+        },
+        "decision": {
+          "requestId": "5b0e6511-bb2d-4d33-814d-b2cdd92f17b7",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:b6460cf75582820024d3d3e9879c7ee40af9db0a5b9318a65dd6b37e083e4637"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:59ed11d78ed2115ec78ee1fd5d7df8baa848bda25d653ef73383b3977743b4e9",
+        "previousReceiptHash": "sha256:b6460cf75582820024d3d3e9879c7ee40af9db0a5b9318a65dd6b37e083e4637",
+        "sequence": 61,
+        "issuedAt": 1787219547122,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:cf39cd48d399ff98f74f14b68f551290931ef269126a121f6925c6b463b85d84"
+            },
+            "now": 1787219547122
+          },
+          "requestId": "58027729-971a-474d-ab86-c37325fd68ee"
+        },
+        "decision": {
+          "requestId": "58027729-971a-474d-ab86-c37325fd68ee",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:ef5f724d3a62e80aebce9d6fa39ccdeb59c812a8004c8dc7f40527df722bad41"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:aa542e3be4bbc6e934c10009bd9bb59e90acaa04f741b484614d5792d638fd3f",
+        "previousReceiptHash": "sha256:ef5f724d3a62e80aebce9d6fa39ccdeb59c812a8004c8dc7f40527df722bad41",
+        "sequence": 62,
+        "issuedAt": 1787219630613,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:d0a524149294ff577942bb36e7ecd7071a68a118dc90e5ca36e501a3d55865ef"
+            },
+            "now": 1787219630613
+          },
+          "requestId": "db9108cf-8b7b-4966-be89-6813bd2a7a3d"
+        },
+        "decision": {
+          "requestId": "db9108cf-8b7b-4966-be89-6813bd2a7a3d",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:f4f9762c2bb0a894012da524158bd50edd42b6e44544e8a6d8edc71096aa28b3"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:26ea713650bf9517d2eba2ceaa5b7a75f284facbc6d0935733423fcd6923ad76",
+        "previousReceiptHash": "sha256:f4f9762c2bb0a894012da524158bd50edd42b6e44544e8a6d8edc71096aa28b3",
+        "sequence": 63,
+        "issuedAt": 1787219639949,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:c87b6400ff789ed6ba42468a313881e34402114bd678ec78f3ee246508704fe7"
+            },
+            "now": 1787219639949
+          },
+          "requestId": "52f5f0ee-5d48-4abc-a8ad-857cf4a094b2"
+        },
+        "decision": {
+          "requestId": "52f5f0ee-5d48-4abc-a8ad-857cf4a094b2",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:b48b9481145ad32dbc091729f3a592c14671832dc64b0fd94f780a51cfe86c19"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:88361ce710d0fe3b0030fbd3d3a6d40c3b95cae6e7a396a64b45d54ff5320370",
+        "previousReceiptHash": "sha256:b48b9481145ad32dbc091729f3a592c14671832dc64b0fd94f780a51cfe86c19",
+        "sequence": 64,
+        "issuedAt": 1787219656058,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:0756c34add0b33de9ebb84fa5d849fe69c1ab05776fb1b33f1388fc88f03c724"
+            },
+            "now": 1787219656058
+          },
+          "requestId": "9611a712-bd87-4e57-bea1-f1b2042c84fc"
+        },
+        "decision": {
+          "requestId": "9611a712-bd87-4e57-bea1-f1b2042c84fc",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:3c25e249d6da1eacd6333f1e36f799410d0108dd14188f81d2f2c98c03d42875"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:8717209498b65098c0bc2f7e4b44f74976cdf27c005ac0a98f33637b7539d631",
+        "previousReceiptHash": "sha256:3c25e249d6da1eacd6333f1e36f799410d0108dd14188f81d2f2c98c03d42875",
+        "sequence": 65,
+        "issuedAt": 1787219667864,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:af5e405d9ebd30ed51a2ac30d6884329a8d5d05cab4e7bb260ecd9f4d63036cc"
+            },
+            "now": 1787219667864
+          },
+          "requestId": "f079a2a4-7546-43f0-9bc5-3e9bdccf474e"
+        },
+        "decision": {
+          "requestId": "f079a2a4-7546-43f0-9bc5-3e9bdccf474e",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:c295165fba985004fd68e914c1f3de72f7f552ddb3e508080c51268ea14c8f70"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:752d6227aa940fc77e56750e85a5ffbd27f6d84a45f95069e3a7b117537e11a5",
+        "previousReceiptHash": "sha256:c295165fba985004fd68e914c1f3de72f7f552ddb3e508080c51268ea14c8f70",
+        "sequence": 66,
+        "issuedAt": 1787219680721,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:ce2aaa2636c388e355c83c5fd8ae98f3fd77eb3e915205dd0c0af2264dc61aba"
+            },
+            "now": 1787219680721
+          },
+          "requestId": "9515e487-0708-464a-86c7-252c43983e87"
+        },
+        "decision": {
+          "requestId": "9515e487-0708-464a-86c7-252c43983e87",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:bce6b1005fcce8049c59adcfc408d45221639600b99bedc5c6ede53dfb009091"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:bb20ea1d1ac015df671cbf5bb90c35714d1a827ce03ea93b690a0b1e490d8d5e",
+        "previousReceiptHash": "sha256:bce6b1005fcce8049c59adcfc408d45221639600b99bedc5c6ede53dfb009091",
+        "sequence": 67,
+        "issuedAt": 1787219689938,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:d1823910dfc61049669565dd2593287d6c9bfdb0ecf25423d62440a0474a2dc2"
+            },
+            "now": 1787219689938
+          },
+          "requestId": "0b2228e9-5ca9-4270-9e2d-cb72153240ed"
+        },
+        "decision": {
+          "requestId": "0b2228e9-5ca9-4270-9e2d-cb72153240ed",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:e3ca4edc9022eacaa50a0051f4cf20e0d96f79b68bbb63f6f04acabd08f4bfea"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:998dd3f8aefb975b0b1fcfc054259bf192e08fbaa77c2e969694924c954ba1a6",
+        "previousReceiptHash": "sha256:e3ca4edc9022eacaa50a0051f4cf20e0d96f79b68bbb63f6f04acabd08f4bfea",
+        "sequence": 68,
+        "issuedAt": 1787219698702,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:6b963cb067c7b459f80b88fa037d88659d13eb9dba67d7766ebf95020bfe9302"
+            },
+            "now": 1787219698702
+          },
+          "requestId": "181f6bcc-23c0-4e6b-b2b0-47b10499c927"
+        },
+        "decision": {
+          "requestId": "181f6bcc-23c0-4e6b-b2b0-47b10499c927",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:2b5b17403f7e14ef0ed6423bc411db2f501838126cf28be6bee9096d463a5fae"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:5274326c500bf7816dcf844c66a1fbff135ba53248dd881f620e8cc2eab22e92",
+        "previousReceiptHash": "sha256:2b5b17403f7e14ef0ed6423bc411db2f501838126cf28be6bee9096d463a5fae",
+        "sequence": 69,
+        "issuedAt": 1787219714820,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:2746fa4ce0910a101c92b2fb57ccafc70f5fb5bad14c80006ee735756dbc9c59"
+            },
+            "now": 1787219714820
+          },
+          "requestId": "b559fb85-ea9e-4e7e-962c-b764e2adecc0"
+        },
+        "decision": {
+          "requestId": "b559fb85-ea9e-4e7e-962c-b764e2adecc0",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:949f01a1f9a8271197ff9fcd6a77b41c5e2861d8d7aca4c74d799804f658e92d"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:44d50ed6200b6261d30317fd826008d9859b7183167d7403a979d1ce28188cb6",
+        "previousReceiptHash": "sha256:949f01a1f9a8271197ff9fcd6a77b41c5e2861d8d7aca4c74d799804f658e92d",
+        "sequence": 70,
+        "issuedAt": 1787219738101,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:24a883e49b3012b75a6c6a453a94a3a40874fbf4cbe8d361bd998bdcfa8eb651"
+            },
+            "now": 1787219738101
+          },
+          "requestId": "9bf66bff-0e1a-4518-9f2b-f0c34c31f670"
+        },
+        "decision": {
+          "requestId": "9bf66bff-0e1a-4518-9f2b-f0c34c31f670",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:3fd9bc54a2ce691855b4a8261e7a645b9958c943b8652b90dac095578eb2fc21"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:afab1f2ca56e03aba0f8a478010216c5e287137871b325c4b8fa669a31f2b7d0",
+        "previousReceiptHash": "sha256:3fd9bc54a2ce691855b4a8261e7a645b9958c943b8652b90dac095578eb2fc21",
+        "sequence": 71,
+        "issuedAt": 1787219751303,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:cc7da69f6d7137e243d90644df8b6582459881017db1d3fadcb58bee6f826b73"
+            },
+            "now": 1787219751303
+          },
+          "requestId": "3bf93086-7d95-4d78-9488-e7402b366d0a"
+        },
+        "decision": {
+          "requestId": "3bf93086-7d95-4d78-9488-e7402b366d0a",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:c1d4fa9328d40e408cba6696c098775a5d0650741a9facf324c4ad079cd45238"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:7a4c8293628ad4acf15b7a1b7619be30c0b1378a1b14a14e07309bf333ea9c49",
+        "previousReceiptHash": "sha256:c1d4fa9328d40e408cba6696c098775a5d0650741a9facf324c4ad079cd45238",
+        "sequence": 72,
+        "issuedAt": 1787219796335,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:d36eb486b2a3d7be07712481c1dfc117a290144116d5e5a86f5e0542d2a5a0ff"
+            },
+            "now": 1787219796335
+          },
+          "requestId": "dddbf2b1-4642-4afe-8600-4d9952666705"
+        },
+        "decision": {
+          "requestId": "dddbf2b1-4642-4afe-8600-4d9952666705",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:cf71927df0ca8aa360eb90e3581bb4a4ef4fda53986afd19e3ce72bd4ff754e3"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:6d3a366d385575654f827da020119fa2f24657fe936eaefe7b1007ecf1c6c2c4",
+        "previousReceiptHash": "sha256:cf71927df0ca8aa360eb90e3581bb4a4ef4fda53986afd19e3ce72bd4ff754e3",
+        "sequence": 73,
+        "issuedAt": 1787219805439,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:27958698362a325f88b8178ebae27aab2229f73a751b2061d001ee15c6ce8235"
+            },
+            "now": 1787219805439
+          },
+          "requestId": "d0ec8469-74b3-4f48-985d-a3a035bdcb76"
+        },
+        "decision": {
+          "requestId": "d0ec8469-74b3-4f48-985d-a3a035bdcb76",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:473ce87e9ad7726255a2ff37706f463e1105a59012f05e5484232f8e8b8a630d"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:e252dce8a3d6e80b6691186011e6299a7ff82cd208fe49c762e9ed46b19da6b9",
+        "previousReceiptHash": "sha256:473ce87e9ad7726255a2ff37706f463e1105a59012f05e5484232f8e8b8a630d",
+        "sequence": 74,
+        "issuedAt": 1787219870429,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:f9719658ee88a58799ac2c386c13f05b35ca9480016096350328005b1a4f57fa"
+            },
+            "now": 1787219870429
+          },
+          "requestId": "b8aa1425-c92c-4bef-ab03-65fc2bd37156"
+        },
+        "decision": {
+          "requestId": "b8aa1425-c92c-4bef-ab03-65fc2bd37156",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:d624367a992d7b9ef3a7c3bafae07a56955dffadf676dc782de33fef74801289"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:b292badbd40fb706083b72dc4355a0ecfa2cfd240267357e63c9c8c2ccb813d3",
+        "previousReceiptHash": "sha256:d624367a992d7b9ef3a7c3bafae07a56955dffadf676dc782de33fef74801289",
+        "sequence": 75,
+        "issuedAt": 1787219878410,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:f342d5800748071e6b41c4b0679c193588ec9f8fbe0b04231f185abaed25da94"
+            },
+            "now": 1787219878410
+          },
+          "requestId": "74719284-d585-4956-aba3-5c1f89a6d5c7"
+        },
+        "decision": {
+          "requestId": "74719284-d585-4956-aba3-5c1f89a6d5c7",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:2320d5e7907cf28ca2fef8455b5af0cd9088910ce370d27d6d03d58736f51b66"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:90ba00fdf25bb2c448d54a03d8605d65cfa425164b771e72d4af2fe2770cceb4",
+        "previousReceiptHash": "sha256:2320d5e7907cf28ca2fef8455b5af0cd9088910ce370d27d6d03d58736f51b66",
+        "sequence": 76,
+        "issuedAt": 1787219887952,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:cdbc277f79af55228112c6c0cd381544a26f14aa5ed705a9ed00cfed13765021"
+            },
+            "now": 1787219887952
+          },
+          "requestId": "efc73b71-6770-4ee3-ae25-c7770825558f"
+        },
+        "decision": {
+          "requestId": "efc73b71-6770-4ee3-ae25-c7770825558f",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:2cfebc1bea35544de1182b059e988390cc96a1e441b1d92279e3537afc4f69c1"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:f1a6fd518b195ac05ab3b8e35a34d59b4326e4b758c5017cdcc593059781840b",
+        "previousReceiptHash": "sha256:2cfebc1bea35544de1182b059e988390cc96a1e441b1d92279e3537afc4f69c1",
+        "sequence": 77,
+        "issuedAt": 1787219958647,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:a911bc965b699e0eb717a899d07155989c9733f3fe0056f0eb90ffcaf10dd1e7"
+            },
+            "now": 1787219958647
+          },
+          "requestId": "956414f0-d6d6-40fe-a859-feaf2b13717d"
+        },
+        "decision": {
+          "requestId": "956414f0-d6d6-40fe-a859-feaf2b13717d",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:ccf3047e0fc86619df3b340a9733070a597dd6fa79bdd9665a08588b1ce115e0"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:46f7da3575fbfb900d278ae4ca329b86fa3018bbcbb241cbee6cc3e29c9d9eca",
+        "previousReceiptHash": "sha256:ccf3047e0fc86619df3b340a9733070a597dd6fa79bdd9665a08588b1ce115e0",
+        "sequence": 78,
+        "issuedAt": 1787219986178,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:f6dd2e02bfefe1d8fca226afda3d31f8e60ef9ce0588669e46d5bc296d02aeff"
+            },
+            "now": 1787219986178
+          },
+          "requestId": "a3fe634f-4d73-4d99-8458-f430b0c50df2"
+        },
+        "decision": {
+          "requestId": "a3fe634f-4d73-4d99-8458-f430b0c50df2",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:1cf50458cbbb4c1b91960e38b2bf590c4a47da2d5a79ce2e625ef649a161a98d"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:6720cb196704d0b6c1a07814d47e7255f4fafbd458f3132034b8e560e77e95bb",
+        "previousReceiptHash": "sha256:1cf50458cbbb4c1b91960e38b2bf590c4a47da2d5a79ce2e625ef649a161a98d",
+        "sequence": 79,
+        "issuedAt": 1787220007231,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:3ecdbb275dd982c612dae7f7748ca03364913f0b0a85472a1b05580b30bdaa8e"
+            },
+            "now": 1787220007231
+          },
+          "requestId": "4fd9e43b-1f38-4ffb-bab8-d64be23f514f"
+        },
+        "decision": {
+          "requestId": "4fd9e43b-1f38-4ffb-bab8-d64be23f514f",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:dadc500c0b097d29f3f2fa223c43f6111b37cde9fd2132e414c28c9bd197aafe"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:9339a89476bb2a77c6da8b64f65668e24356253197a7e2b5add9526170e83d73",
+        "previousReceiptHash": "sha256:dadc500c0b097d29f3f2fa223c43f6111b37cde9fd2132e414c28c9bd197aafe",
+        "sequence": 80,
+        "issuedAt": 1787220016915,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:503788c443530ddd4b307ef384972c886ba81b3fbf3c8db83080e7585565f45d"
+            },
+            "now": 1787220016915
+          },
+          "requestId": "4701002c-b4aa-4d5f-848e-7bfc5d3eabee"
+        },
+        "decision": {
+          "requestId": "4701002c-b4aa-4d5f-848e-7bfc5d3eabee",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:c5cd13ba161613d86bdd4344208617657788b5428dd39db44f682fa502b688ff"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:2637ff4d88da6188fb6320c94ff647aca5cdf31707f21c0bbd032413247ef683",
+        "previousReceiptHash": "sha256:c5cd13ba161613d86bdd4344208617657788b5428dd39db44f682fa502b688ff",
+        "sequence": 81,
+        "issuedAt": 1787220074837,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:73eecbcd16637b01066b625be8c509ce6d115856ad11d9691d7416fb0ffdf24f"
+            },
+            "now": 1787220074837
+          },
+          "requestId": "f36776b9-08d8-4765-a9e3-3524e1a8eed5"
+        },
+        "decision": {
+          "requestId": "f36776b9-08d8-4765-a9e3-3524e1a8eed5",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:0cddf17e514cddf483cebd526854a81a6679fe8ad32878558bb66e98f1bdabce"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:8bf90b977fe280f46c3d9ea0e985165935bf4110e6c9bcad47cba66b5dc881b1",
+        "previousReceiptHash": "sha256:0cddf17e514cddf483cebd526854a81a6679fe8ad32878558bb66e98f1bdabce",
+        "sequence": 82,
+        "issuedAt": 1787220083821,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:05399dd90c11dc920f68479c063a65010de6cecc5fab9e7b9763d62aace6e0f1"
+            },
+            "now": 1787220083821
+          },
+          "requestId": "6d4ae22c-273e-4dd9-8d63-d489b1886de9"
+        },
+        "decision": {
+          "requestId": "6d4ae22c-273e-4dd9-8d63-d489b1886de9",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:0a6b01581c24230b7bd7ee017309db391eee38fd438167f8189b1b380d26d66d"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:111ebe06297d004d1169b55c2b8c7a50b169d07e6cf9560ef43be08dbe92c7df",
+        "previousReceiptHash": "sha256:0a6b01581c24230b7bd7ee017309db391eee38fd438167f8189b1b380d26d66d",
+        "sequence": 83,
+        "issuedAt": 1787220103197,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:7f5ba086917398500721489ba67a036087657275799a45337ab0a716792ec9d2"
+            },
+            "now": 1787220103197
+          },
+          "requestId": "169e4332-383d-425e-b81b-6cd60fcf9f4c"
+        },
+        "decision": {
+          "requestId": "169e4332-383d-425e-b81b-6cd60fcf9f4c",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:23bb704770b78fcc8efe1a2782c221537624c4a9811094318dba23b27770f2bc"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:a99b8f1bc56eef1fac82c3d6be4b91dfe0623f414790022e19af25e97e15a12e",
+        "previousReceiptHash": "sha256:23bb704770b78fcc8efe1a2782c221537624c4a9811094318dba23b27770f2bc",
+        "sequence": 84,
+        "issuedAt": 1787220169206,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-edit",
+            "tool": "hooks_post-edit",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:3c5fa621ffe43ca944f78c09a84a35471bf87716650cc6ee97961bbbb398c5a0"
+            },
+            "now": 1787220169206
+          },
+          "requestId": "721d4bc0-f5b2-4413-b86b-b7cb17f8964b"
+        },
+        "decision": {
+          "requestId": "721d4bc0-f5b2-4413-b86b-b7cb17f8964b",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:057f25571a502542195ae489a7012e1fda87438d7296824e9392ff82f21d7f63"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:a5ec13746cc4c608edf3552078fd119b0d37275ab32c38e98221808b348a2a3a",
+        "previousReceiptHash": "sha256:057f25571a502542195ae489a7012e1fda87438d7296824e9392ff82f21d7f63",
+        "sequence": 85,
+        "issuedAt": 1787220185028,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:e24c176493aae074ef3910bcbf7db2a73a826fe780194ad2d2205085c3601260"
+            },
+            "now": 1787220185028
+          },
+          "requestId": "9185d9c5-46a1-48a7-b403-4152d2f19530"
+        },
+        "decision": {
+          "requestId": "9185d9c5-46a1-48a7-b403-4152d2f19530",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:93011d05426a7949b0995bd5494c4730cae77b7f646e8018878523aca8560ccf"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:e8ccf7afacd62fc19506578e9d337dd78dc986fbaab4f0939b3cb70bc6f1dad6",
+        "previousReceiptHash": "sha256:93011d05426a7949b0995bd5494c4730cae77b7f646e8018878523aca8560ccf",
+        "sequence": 86,
+        "issuedAt": 1787220192633,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:46e29cdff286a1fb572fb07f726e05968266764292dce6efc0cd5f8b54290c49"
+            },
+            "now": 1787220192633
+          },
+          "requestId": "ab568799-5547-453d-a1b6-96ef80dcbd0e"
+        },
+        "decision": {
+          "requestId": "ab568799-5547-453d-a1b6-96ef80dcbd0e",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:84a8a970cadce54cbff2078989c45c6c2b2095259524b03d7a735c61581c5ad2"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:7429c465a860f5c2da403366a6c21526f874e6d73d9d2e7327c4bb3009b141ed",
+        "previousReceiptHash": "sha256:84a8a970cadce54cbff2078989c45c6c2b2095259524b03d7a735c61581c5ad2",
+        "sequence": 87,
+        "issuedAt": 1787220203880,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:febfdf553eabab7efc1b60b7207fcf82246676a94e060af76b54f91c7737bfce"
+            },
+            "now": 1787220203880
+          },
+          "requestId": "7f0f2bc3-c1d7-41d0-9b50-8b8dce826847"
+        },
+        "decision": {
+          "requestId": "7f0f2bc3-c1d7-41d0-9b50-8b8dce826847",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:326f111a7266e38482b70dbfe3854d1257431c5c73917254714fbb337e335d11"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:244b056986db68626648642da0a5ba390ca3bec0f9b5c98a44304b41031b529a",
+        "previousReceiptHash": "sha256:326f111a7266e38482b70dbfe3854d1257431c5c73917254714fbb337e335d11",
+        "sequence": 88,
+        "issuedAt": 1787220213968,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:a03bbeb9dbf041dabb1d2c552bb30bfbcbbcc7aca64e3ef72655ba9c4e51d7de"
+            },
+            "now": 1787220213968
+          },
+          "requestId": "9f3f6504-a3f8-400b-a65a-b6b5e83e896c"
+        },
+        "decision": {
+          "requestId": "9f3f6504-a3f8-400b-a65a-b6b5e83e896c",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:042100c566d804d77a35cc6f9922c1de4753d21f0dc6995d7d8cc4ad98e42a03"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:2d956f24233480175581b0e1e45ddb97ef0cd20860927a75eeff20d83a3f0bbd",
+        "previousReceiptHash": "sha256:042100c566d804d77a35cc6f9922c1de4753d21f0dc6995d7d8cc4ad98e42a03",
+        "sequence": 89,
+        "issuedAt": 1787220231935,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_post-command",
+            "tool": "hooks_post-command",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:f228fa2173135045b797f355c7c95ed2633c2fb621334642f7c088ad536bca7b"
+            },
+            "now": 1787220231935
+          },
+          "requestId": "3795c1af-a786-4082-8d83-dba3e2b3ee85"
+        },
+        "decision": {
+          "requestId": "3795c1af-a786-4082-8d83-dba3e2b3ee85",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:cfe13a0bde8b7f2b10940d452fa6c90433d26a7bf61e240a04e5e8bb4fff3ac5"
+    },
+    {
+      "payload": {
+        "receiptId": "sha256:5bf58d2befca786731a447c0f994044b0b291623e54e5042ec0cee96ac54c2f5",
+        "previousReceiptHash": "sha256:cfe13a0bde8b7f2b10940d452fa6c90433d26a7bf61e240a04e5e8bb4fff3ac5",
+        "sequence": 90,
+        "issuedAt": 1787220250589,
+        "request": {
+          "identity": {
+            "id": "legacy-cli",
+            "type": "legacy"
+          },
+          "action": {
+            "type": "mcp.tool.call",
+            "resource": "hooks_session-end",
+            "tool": "hooks_session-end",
+            "server": "ruflo",
+            "network": false,
+            "destructive": false
+          },
+          "context": {
+            "metadata": {
+              "inputDigest": "sha256:b647b3f3b1fa4ad9e39e3be91a77b8f4c491ae0d5a7b91cd1ca4f1c1ac19cf94"
+            },
+            "now": 1787220250589
+          },
+          "requestId": "4646c790-5bb9-4692-be32-e745cb9a85b1"
+        },
+        "decision": {
+          "requestId": "4646c790-5bb9-4692-be32-e745cb9a85b1",
+          "outcome": "allowed",
+          "enforcedOutcome": "allowed",
+          "mode": "legacy",
+          "reason": "legacy-default-allow",
+          "matchedRules": [],
+          "obligations": []
+        },
+        "policyHash": "sha256:00b63b2f746eb8b9095bbd5e1dbae4ddd74fd92a6740b72f59f4069fbfda4737"
+      },
+      "hash": "sha256:0334d14fa52274b8ce4e7d97053da3d1f6e2e77c7d64edd0e59220f64145d623"
+    }
+  ],
+  "migratedAt": 1787216624025,
+  "migratedFrom": "pre-ADR-324; capabilities=none-detected"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
  "apple-xar",
  "base64 0.22.1",
  "bcder",
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "bytes",
  "chrono",
  "clap",
@@ -193,7 +193,7 @@ dependencies = [
  "spki",
  "subtle",
  "tempfile",
- "thiserror 2.0.3",
+ "thiserror 2.0.20",
  "tokio",
  "tungstenite",
  "uuid",
@@ -221,7 +221,7 @@ dependencies = [
  "scroll",
  "serde",
  "serde-xml-rs",
- "thiserror 2.0.3",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -247,7 +247,7 @@ dependencies = [
  "sha1",
  "sha2",
  "signature",
- "thiserror 2.0.3",
+ "thiserror 2.0.20",
  "url",
  "x509-certificate",
  "xml-rs",
@@ -397,11 +397,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -767,6 +767,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "codira_comptime"
+version = "0.6.0-dev"
+dependencies = [
+ "codira_mir",
+ "rustc-hash 1.1.0",
+ "smol_str",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "codira_diagnostics"
 version = "0.6.0-dev"
 dependencies = [
@@ -792,8 +802,10 @@ dependencies = [
 name = "codira_hir"
 version = "0.6.0-dev"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
+ "codira_comptime",
  "codira_hir_input",
+ "codira_mir",
  "codira_paths",
  "codira_syntax",
  "codira_target",
@@ -870,6 +882,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "codira_lld"
+version = "220.0.0"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "llvm-sys",
+ "semver",
+]
+
+[[package]]
 name = "codira_memory"
 version = "0.6.0-dev"
 dependencies = [
@@ -883,6 +906,15 @@ dependencies = [
  "paste",
  "rustc-hash 1.1.0",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "codira_mir"
+version = "0.6.0-dev"
+dependencies = [
+ "la-arena",
+ "smallvec",
+ "smol_str",
 ]
 
 [[package]]
@@ -1744,7 +1776,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "ignore",
  "walkdir",
 ]
@@ -2190,27 +2222,26 @@ dependencies = [
 
 [[package]]
 name = "inkwell"
-version = "0.2.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4fcb4a4fa0b8f7b4178e24e6317d6f8b95ab500d8e6e1bd4283b6860e369c1"
+checksum = "30932a1258d02e3c7344618abcdbb5dca03e0f8d2ad34496067d1f371cfceda6"
 dependencies = [
- "either",
+ "bitflags 2.13.1",
  "inkwell_internals",
  "libc",
  "llvm-sys",
- "once_cell",
- "parking_lot 0.12.3",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "inkwell_internals"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b185e7d068d6820411502efa14d8fbf010750485399402156b72dd2a548ef8e9"
+checksum = "04a85f1cf8de4f1df2ebd93b6afe957fa2acd0081c97dabfa41651eeeb44756e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2466,7 +2497,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "libc",
  "redox_syscall 0.5.7",
 ]
@@ -2491,14 +2522,15 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "llvm-sys"
-version = "140.1.3"
+version = "221.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3dc78e9857c0231ec11e3bdccf63870493fdc7d0570b0ea7d50bf5df0cb1a0c"
+checksum = "2abcc34a3b190f03c2a61b555f218f529589ff13657bdd2ff8ac3e85f2abe6bb"
 dependencies = [
+ "anyhow",
  "cc",
  "lazy_static",
  "libc",
- "regex",
+ "regex-lite",
  "semver",
 ]
 
@@ -2732,7 +2764,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "cfg-if 1.0.0",
  "cfg_aliases",
  "libc",
@@ -3245,7 +3277,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "memchr",
  "unicase",
 ]
@@ -3256,7 +3288,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76979bea66e7875e7509c4ec5300112b316af87fa7a252ca91c448b32dfe3993"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "memchr",
  "pulldown-cmark-escape",
  "unicase",
@@ -3290,7 +3322,7 @@ dependencies = [
  "rustc-hash 2.1.0",
  "rustls",
  "socket2",
- "thiserror 2.0.3",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -3309,7 +3341,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.3",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3514,7 +3546,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3550,6 +3582,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
@@ -3650,7 +3688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "serde",
  "serde_derive",
 ]
@@ -3729,7 +3767,7 @@ version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3912,7 +3950,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3925,7 +3963,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -3959,10 +3997,11 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -3979,14 +4018,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.215"
+name = "serde_core"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4238,6 +4286,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4347,11 +4406,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -4367,13 +4426,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5433,7 +5492,7 @@ dependencies = [
  "flate2",
  "indexmap 2.6.0",
  "memchr",
- "thiserror 2.0.3",
+ "thiserror 2.0.20",
  "zopfli",
 ]
 

--- a/agents/EMBEDDING_CODIRA.md
+++ b/agents/EMBEDDING_CODIRA.md
@@ -1,0 +1,490 @@
+<!--
+Copyright (c) 2026 Omnira CJSC
+Author: Tunjay Akbarli
+Date: August 12, 2026
+
+Functionality: Instructions for AI coding agents — how to EMBED a compiled
+Codira library into a *different* host project (Rust, C, or C++), as opposed
+to writing Codira source itself (see `USING_CODIRA.md`) or building the
+Codira compiler (see `spec/LANGUAGE_SPEC.md` §12-§15 and `crates/**`).
+-->
+
+# Embedding Codira in a Host Project — Agent Instructions
+
+This document teaches an AI coding agent how to take an **already-written**
+Codira package (a `codira.toml` + `src/**/*.code` tree) and **load, drive, and
+hot-reload it from a different project** — a Rust binary, a C application, or
+a C++ application. If the task is instead "write some Codira source code",
+read `USING_CODIRA.md` first; this document assumes that part is done and
+focuses purely on the host-side integration.
+
+> **Ground truth.** Everything below was verified directly against this
+> repository's source on 2026-08-12: `crates/codira_runtime/src/**`,
+> `crates/codira_runtime_capi/src/**`, `crates/codira_capi_utils/src/**`,
+> `cpp/include/codira/**`, `c/include/codira/abi.h`, `book/src/ch02-04-extern-fn.md`,
+> `book/src/ch04-04-hot-reloading.md`, and the `examples/rust-pong`,
+> `examples/rust-spaceship`, `examples/rust-bevy-simple`,
+> `examples/codira-extern`, `examples/codira-marshal` example projects. Where
+> this guide and the actual crate/header source disagree, trust the source.
+
+---
+
+## 0. Read this before writing any `.code` file for a host project
+
+The single most important trap in this repository: **`spec/LANGUAGE_SPEC.md`
+describes a *new* keyword surface (`func`/`public`/`var`/`import`/`extend`,
+`struct` vs `class` as the memory-kind keyword itself), but every example
+project under `examples/**` and the entire `std/` tree still contains the
+*old*, pre-redesign syntax** (`fn`, `pub fn`, `struct(value)`/`struct(gc)`,
+`use` instead of `import`). This is explicitly documented as unfinished
+migration work in `spec/LANGUAGE_SPEC.md` §13 ("Every example's `.code` file
+content ... still contains pre-redesign Codira syntax") and confirmed by
+direct inspection:
+
+- `examples/codira-extern/src/mod.code`, `examples/codira-marshal/src/mod.code`,
+  `examples/rust-pong/codira/src/mod.code`, and the buoyancy listings all use
+  `fn`/`pub fn`/`struct(value) Foo {}`/`struct(gc) Foo {}` — **none of this
+  parses under the current grammar** (`fn`, `pub`, and the `(gc)`/`(value)`
+  parenthetical annotation were removed as keywords/syntax).
+- `book/src/**` is a **mixed bag**: some listings (e.g.
+  `book/listings/ch02-basic-concepts/*.code`, `ch04-structs/listing13.code`,
+  `listing01.code`/`listing02.code` in ch04-structs) already use the new
+  syntax (`func`, `public func`, plain `struct Foo { x: f32 }`), but the spec
+  itself notes the book's doctest suite is only 16/47 passing overall — do
+  not assume an arbitrary book listing compiles without checking it.
+- `std/**` (the in-progress standard library) mixes old syntax
+  (`struct(value) Optional[T] {}`, `use std.builtin.traits;`) with syntax
+  the compiler doesn't support at all yet even under the new grammar
+  (`func Error.new(message: String) -> Error { }` — declaring an associated
+  function outside an `extend` block is not part of the spec's own grammar).
+  **Treat `std/` as a design reference only, never as code guaranteed to
+  compile.**
+
+**Rule for agents:** when you write new `.code` source that a host project
+will embed, always use the syntax in `spec/LANGUAGE_SPEC.md` §1-§11 (the same
+rules documented in `USING_CODIRA.md`), never copy an `examples/**` or
+`std/**` file verbatim as if it reflects current syntax. Then confirm with a
+real `codira build` before wiring up the host side.
+
+Also respect the implementation-status split from `USING_CODIRA.md` §5 when
+designing the Codira side of an embedding: **only** `struct`, `class`, `func`,
+`let`/`var`, field access, arithmetic/comparisons, `if`/`else`, `for`/`while`,
+function calls, `extern` function declarations, and `import`/visibility are
+verified end-to-end through parse → HIR → LLVM → link → run. `enum`, `trait`,
+`match`, `effect`/`handle`/`perform`, `comptime`, generics-at-runtime,
+multiple-dispatch overloads, and `Type.method()` associated-function calls
+currently parse but are **not** safe to depend on for a host integration —
+avoid designing the Codira side of an embedded script around them for now.
+
+---
+
+## 1. Why embed Codira at all
+
+Codira is designed the way `mun-lang` was: not as a standalone executable
+language, but as an **ahead-of-time-compiled, hot-reloadable scripting/logic
+layer that a native host application loads as a library**. `codira build`
+never produces an OS executable — it produces `target/<module>.codiralib`, a
+dynamic library with a stable C-compatible ABI. A host process:
+
+1. Loads that `.codiralib` (and its dependencies) through the **Codira
+   Runtime**.
+2. Supplies implementations for any `extern` functions the Codira code
+   declared (the Codira → host direction).
+3. Calls public Codira functions by name (the host → Codira direction).
+4. Optionally polls the runtime once per frame/tick so that, while the
+   compiler is running in `--watch` mode and recompiling on save, the host
+   process swaps in the new code **without restarting** — this is
+   hot-reloading, and it is the feature this whole architecture exists for.
+
+There are three ways to be "the host", depending on the host language:
+
+| Host language | What you link against | Primary source of truth |
+|---|---|---|
+| Rust | the `codira_runtime` crate | `crates/codira_runtime/src/lib.rs`, `adt.rs`, `array.rs` |
+| C | `codira_runtime_capi` (built as a C-ABI library) + `c/include/codira/abi.h` | `crates/codira_runtime_capi/src/**` |
+| C++ | the header-only wrapper in `cpp/include/codira/**` (itself built on the C API) | `cpp/include/codira/runtime.h`, `struct_ref.h`, `array_ref.h`, `marshal.h` |
+
+All three are different faces on the exact same underlying runtime; the Rust
+API is the most complete/idiomatic and is what every example project in this
+repo actually uses (`examples/rust-pong`, `examples/rust-spaceship`,
+`examples/rust-bevy-simple`, `examples/buoyancy`).
+
+---
+
+## 2. Project layout for an embedding
+
+The convention used throughout `examples/**` is a host project that contains
+a full, nested Codira package:
+
+```
+my_host_project/
+├── Cargo.toml                 # (or CMakeLists.txt for C/C++)
+├── src/
+│   └── main.rs                # loads and drives the runtime
+└── codira/                      # a complete, independent Codira package
+    ├── codira.toml
+    └── src/
+        └── mod.code
+```
+
+Nothing links the two build systems together automatically — `cargo
+build`/`cmake` builds the host binary, and `codira build` (run separately,
+typically with `--watch`) produces the `.codiralib` that the host loads *at
+runtime* by path. This is why every example's README says to run two
+commands in two terminals (see `examples/rust-pong/README.md`):
+
+```bash
+# terminal 1 — compiler daemon, rebuilds on every save
+codira build --watch --manifest-path=my_host_project/codira/codira.toml
+
+# terminal 2 — the host binary, which loads codira/target/mod.codiralib
+cargo run
+```
+
+---
+
+## 3. Embedding from Rust (the primary, best-supported path)
+
+### 3.1 Dependency
+
+```toml
+# Cargo.toml
+[dependencies]
+codira_runtime = { path = "../../crates/codira_runtime" }
+```
+
+This repository does not appear to publish `codira_runtime` to crates.io (no
+`[package.publish]`/registry metadata was found and every example uses a
+relative `path` dependency) — use a path or git dependency, not a version
+requirement, unless you've confirmed a registry release exists.
+
+### 3.2 Loading a library and calling into it
+
+```rust
+use codira_runtime::Runtime;
+
+fn main() {
+    // Safety: the caller is asserting the file at this path is a
+    // Codira-compiler-produced .codiralib. Runtime::builder().finish() is
+    // `unsafe` for exactly this reason — it does not re-validate the file.
+    let builder = Runtime::builder("codira/target/mod.codiralib");
+    let mut runtime = unsafe { builder.finish() }.expect("Failed to spawn Runtime");
+
+    // Turbofish/annotation picks which Rust type the Codira return value is
+    // marshalled into; argument types are inferred from the tuple.
+    let result: i64 = runtime.invoke("some_function", (1i64, 2i64)).unwrap();
+    println!("{result}");
+}
+```
+
+Key API surface on `codira_runtime::Runtime` / `RuntimeBuilder`
+(`crates/codira_runtime/src/lib.rs`):
+
+- `Runtime::builder<P: Into<PathBuf>>(library_path) -> RuntimeBuilder`
+- `RuntimeBuilder::insert_fn<S: Into<String>, F>(name, function) -> RuntimeBuilder`
+  — registers a host function that satisfies an `extern` declaration in the
+  Codira source (see §3.3). Chainable — call it once per `extern` function.
+- `unsafe { builder.finish() } -> Result<Runtime, InitError>` — actually
+  loads the library and links `extern` symbols. `unsafe` because it trusts
+  the library path/contents.
+- `runtime.invoke::<ReturnType, ArgTypes>(function_name: &str, arguments) ->
+  Result<ReturnType, InvokeErr<...>>` — calls a **public** Codira function.
+  `ArgTypes` is a tuple (`()`, `(i64,)`, `(f32, StructRef)`, …); trailing
+  comma required for one-argument tuples.
+- `unsafe { runtime.update(&mut self) -> bool }` — polls for a hot-reloaded
+  library and swaps it in if the watching compiler produced a new build;
+  returns whether an update happened. Call this once per host frame/tick if
+  you started the compiler with `--watch`. `unsafe` for the same
+  code-swap-under-your-feet reason `finish()` is.
+- `runtime.get_function_definition(name) -> Option<Arc<FunctionDefinition>>`,
+  `get_type_info_by_name`/`get_type_info_by_id` — reflection, useful for
+  generic tooling rather than typical gameplay code.
+- `runtime.gc() -> &GarbageCollector`, `runtime.gc_collect() -> bool`,
+  `runtime.gc_stats() -> gc::Stats` — the Codira heap is a separate,
+  runtime-managed GC; you generally don't need to drive it manually.
+- `runtime.construct_array<...>` / `construct_typed_array<...>` — build a
+  Codira-side array from a Rust iterator to pass into `invoke`.
+
+### 3.3 `extern` functions — Codira calling into the host
+
+A Codira function declared `extern` has no body; the *host* must supply the
+implementation before the library can be loaded, or `finish()` fails at link
+time:
+
+```codira
+extern func random() -> i64;
+
+public func random_bool() -> bool {
+    random() % 2 == 0
+}
+```
+
+```rust
+use codira_runtime::Runtime;
+
+extern "C" fn random() -> i64 {
+    std::time::Instant::now().elapsed().subsec_nanos() as i64
+}
+
+fn main() {
+    let builder = Runtime::builder("main.codiralib")
+        .insert_fn("random", random as extern "C" fn() -> i64);
+    let mut runtime = unsafe { builder.finish() }.expect("Failed to spawn Runtime");
+    let result: bool = runtime.invoke("random_bool", ()).unwrap();
+}
+```
+
+Two things that will bite you if skipped:
+
+- The Rust function **must** be `extern "C"` and must be cast to its
+  explicit `extern "C" fn(...) -> ...` type at the `insert_fn` call site —
+  every Rust function has a distinct anonymous type, so the cast is what
+  makes it match the ABI-level function pointer `insert_fn` expects.
+- If you forget an `extern` binding, `finish()` returns an error whose
+  message is literally `Failed to link: function `<name>` is missing.` —
+  that error means "call `.insert_fn` for this name", not a build problem on
+  the Codira side.
+
+### 3.4 Structs across the boundary: `StructRef`, `RootedStruct`, `ArrayRef`
+
+Codira `struct`/`class` values crossing into Rust show up as
+`codira_runtime::StructRef<'s>` — a typed-but-reflective handle, borrowed from
+the runtime and **not** rooted (i.e., eligible for GC unless you root it):
+
+```rust
+use codira_runtime::{Runtime, StructRef, RootedStruct};
+
+let state: StructRef = runtime.invoke("new_state", ()).unwrap();
+let state: RootedStruct = state.root();       // keep it alive across GC cycles
+
+// later, any time you need it again as a StructRef to read/write fields:
+let state_ref = state.as_ref(&runtime);
+let score: u32 = state_ref.get("score").unwrap();
+let mut paddle: StructRef = state_ref.get("paddle_left").unwrap();
+paddle.set("move_up", true).unwrap();
+```
+
+- `StructRef::get::<T>(field_name) -> Result<T, String>` and
+  `StructRef::set::<T>(field_name, value) -> Result<(), String>` /
+  `replace::<T>(...)` are the field accessors; `T` must implement the
+  runtime's `Marshal` trait (see §3.5) and its static type must match the
+  field's declared Codira type or you get a descriptive `Err`, not a panic.
+- `.root()` converts a `StructRef` into an owned `RootedStruct` that keeps
+  the GC from collecting it — store this in your host-side game/app state,
+  not the borrowed `StructRef`.
+- `RootedStruct::as_ref(&runtime) -> StructRef` converts back when you need
+  to actually read/write it; this is the standard pattern seen throughout
+  `examples/rust-pong/src/main.rs`.
+- Arrays follow the same rooted/unrooted split via `ArrayRef<'a, T>`
+  (`crates/codira_runtime/src/array.rs`).
+- **Struct value-vs-reference kind is transparent to you as the host.**
+  Whether the Codira type is a value `struct` or a GC `class`, you always get
+  back a `StructRef`/heap handle at the FFI boundary — the compiler
+  auto-boxes value-struct returns/arguments onto the GC heap specifically for
+  cross-boundary calls (see the dispatch-table bug/fix described in
+  `spec/LANGUAGE_SPEC.md` §15 for exactly why this had to be made consistent).
+  You don't need to special-case `struct` vs `class` on the Rust side.
+
+### 3.5 What marshals directly (no `StructRef` needed)
+
+`crates/codira_runtime/src/reflection.rs` implements `ArgumentReflection` /
+`ReturnTypeReflection` (the traits `Marshal` builds on) for these primitive
+Rust types, which map 1:1 to Codira's primitive types of the same
+bit-width: `bool`, `f32`, `f64`, `i8`, `i16`, `i32`, `i64`, `i128`, `u8`,
+`u16`, `u32`, `u64`, `u128`. `()` marshals for a Codira function with no
+return value. Anything else — `struct`/`class` instances and arrays — goes
+through `StructRef`/`ArrayRef` as shown above.
+
+There is **no** built-in marshalling for `String`/text. `examples/codira-marshal`
+(which exercises every primitive pairwise) has 128-bit ints and their
+struct-wrapped forms commented out with `// TODO: Add 128-bit integers`,
+even though the reflection macro list above does include `i128`/`u128` —
+treat 128-bit and any string/collection marshalling as **unverified**; test
+it directly before depending on it, and prefer plain fixed-width
+scalars/structs for anything you need working today.
+
+### 3.6 Hot reload from the host side
+
+Hot reload requires nothing extra beyond calling `unsafe {
+runtime.update() }` periodically (once per frame is typical — see
+`examples/rust-pong/src/main.rs`'s `update()` handler and
+`book/listings/ch04-structs/listing14.rs`'s main loop) while a `codira build
+--watch` process is recompiling the same library on save. What survives a
+reload and how, per `book/src/ch04-04-hot-reloading.md` (verified accurate
+against that chapter):
+
+- Struct/array hot reload applies **recursively** (a struct containing a
+  struct field, or an array of structs, reloads correctly).
+- A newly **inserted** field is recursively zero-initialized on next reload.
+- Field-diffing priority when a struct's shape changes between reloads:
+  1. Same name + same type → unchanged, the value is **moved** as-is.
+  2. Same name, different type → treated as the same field undergoing a
+     **type conversion** (and possibly moved).
+  3. Different name, same type → treated as a possible **rename** (nearest
+     original-index candidate wins when ambiguous).
+- Restrictions: a struct can't simultaneously be renamed **and** have its
+  fields edited in the same reload; a field can't simultaneously be renamed
+  **and** type-converted. Either case is instead treated as an independent
+  insertion + deletion.
+- Practical trick used in the book's tutorial: add a throwaway `token: u32`
+  field plus a `hot_reload_token() -> u32` extern/const function that you
+  bump by hand; compare it once per reload to run one-time re-initialization
+  logic against the freshly hot-reloaded state, then delete the scaffolding
+  once you're done iterating.
+
+---
+
+## 4. Embedding from C
+
+The C ABI is exposed by the `codira_runtime_capi` crate
+(`crates/codira_runtime_capi/src/**`), built as a C-compatible library; the
+matching `abi.h` (struct/type layout definitions, not the runtime API itself)
+lives at `c/include/codira/abi.h`. The **complete** list of exported C
+functions, taken directly from `#[no_mangle] pub extern "C" fn` in that
+crate plus its `codira_capi_utils` dependency, is:
+
+```
+codira_runtime_create(library_path: *const c_char, options: RuntimeOptions, handle: *mut Runtime) -> ErrorHandle
+codira_runtime_destroy(runtime: Runtime) -> ErrorHandle
+codira_runtime_update(runtime: Runtime, updated: *mut bool) -> ErrorHandle
+codira_runtime_find_function_definition(...) -> ErrorHandle
+codira_runtime_get_type_info_by_name(...) -> ErrorHandle
+codira_runtime_get_type_info_by_id(...) -> ErrorHandle
+
+codira_gc_alloc(runtime: Runtime, ty: Type, obj: *mut GcPtr) -> ErrorHandle
+codira_gc_ptr_type(...) -> ErrorHandle
+codira_gc_root(runtime: Runtime, obj: GcPtr) -> ErrorHandle
+codira_gc_unroot(runtime: Runtime, obj: GcPtr) -> ErrorHandle
+codira_gc_collect(runtime: Runtime, reclaimed: *mut bool) -> ErrorHandle
+
+codira_function_add_reference(function: Function) -> ErrorHandle
+codira_function_release(function: Function) -> ErrorHandle
+codira_function_fn_ptr(...) -> ErrorHandle
+codira_function_name(...) -> ErrorHandle
+codira_function_argument_types(...) -> ErrorHandle
+codira_function_return_type(...) -> ErrorHandle
+
+codira_error_destroy(error: ErrorHandle)
+codira_string_destroy(string: *const c_char)
+```
+
+Conventions to follow when calling this API directly from C:
+
+- **Error handling.** Nearly every function returns `ErrorHandle` (`struct
+  ErrorHandle(*const c_char)`, `crates/codira_capi_utils/src/error.rs`).
+  `ErrorHandle::is_ok()` corresponds to a null inner pointer; a non-null
+  handle carries a C string error message you can read and **must** free
+  with `codira_error_destroy` once you're done with it.
+- **Startup:** call `codira_runtime_create(library_path, options, &mut
+  handle)`. `options: RuntimeOptions { functions: *const
+  ExternalFunctionDefinition, num_functions: u32 }` is how you supply
+  `extern` bindings up front (the C equivalent of Rust's chained
+  `insert_fn` calls) — build the array of `ExternalFunctionDefinition`
+  (name, arg types, return type, raw `fn_ptr`) before the single create
+  call, there is no incremental "insert" call in the C API.
+- **Shutdown:** `codira_runtime_destroy(runtime)`.
+- **Hot reload:** call `codira_runtime_update(runtime, &mut updated)`
+  periodically, exactly like the Rust `runtime.update()`.
+- **GC:** `codira_gc_root`/`codira_gc_unroot` around any `GcPtr` you hold
+  onto outside of a single call (the C-level equivalent of Rust's
+  `StructRef::root()` → `RootedStruct`), `codira_gc_collect` to force a
+  collection, `codira_gc_alloc` to allocate Codira-managed memory directly.
+
+Because this is a raw C ABI, prefer the C++ wrapper (§5) or the Rust API
+(§3) whenever the host language allows it — they add lifetime/RAII/type
+safety over the exact same underlying calls.
+
+---
+
+## 5. Embedding from C++
+
+`cpp/include/codira/**` is a **header-only** C++ wrapper around the C API in
+§4 — link against the same `codira_runtime_capi`-produced library, but write
+idiomatic C++ against these headers instead of the raw `extern "C"`
+functions:
+
+| Header | Purpose |
+|---|---|
+| `codira.h` | umbrella include |
+| `runtime.h` | `codira::Runtime` — RAII wrapper: construction/`make_runtime(library_path, RuntimeOptions, Error*)`, `update(Error* = nullptr)`, `gc_alloc`/`gc_collect`/`gc_root_ptr`/`gc_unroot_ptr`/`ptr_type`, `find_function_info` |
+| `struct_ref.h` | C++ equivalent of Rust's `StructRef` |
+| `array_ref.h` | C++ equivalent of Rust's `ArrayRef` |
+| `marshal.h` | primitive marshalling glue |
+| `function.h`, `runtime_function.h` | typed function handles/invocation |
+| `reflection.h`, `type.h`, `struct_type.h`, `array_type.h`, `field_info.h`, `static_type_info.h` | reflection/type-info surface |
+| `error.h` | RAII `Error` wrapper over `ErrorHandle` |
+| `gc.h` | GC pointer type (`CodiraGcPtr`) |
+| `runtime_capi.h` | the raw C declarations the rest of these headers build on |
+
+`Runtime`'s constructor takes a `CodiraRuntime` C handle and is move-only
+(`Runtime(Runtime&&)`); the free function that actually creates one takes the
+library path plus a `RuntimeOptions`-equivalent (a list of
+`CodiraExternalFunctionDefinition`s, each type-reference-counted via
+`codira_type_add_reference` internally) and an optional `Error*` out-parameter,
+mirroring the Rust `RuntimeBuilder`/C `codira_runtime_create` shape one-to-one.
+`update()` and the `gc_*` methods forward directly to the C functions in §4
+with the same semantics (e.g. `update(Error* out_error = nullptr)` returns
+whether a reload occurred, `CODIRA_ASSERT`-wrapping the C call otherwise).
+
+---
+
+## 6. Two-directional interop from the Codira side
+
+Everything above is the *host's* view. The Codira-source side of the same
+contract (declared in `spec/LANGUAGE_SPEC.md` §10) is:
+
+```codira
+extern "C" {
+    func sqrt(x: f64) -> f64;
+    func malloc(size: usize) -> RawPointer[u8];
+}
+
+@export("C")                      // expose this Codira function to C/C++/Rust callers
+public func codira_add(a: i32, b: i32) -> i32 { a + b }
+```
+
+- A bare `extern func name(...) -> T;` (no `"C"`/`"C++"` block, as used by
+  `runtime.insert_fn`/`RuntimeOptions` in §3-§4) is the *runtime-supplied*
+  extern mechanism — resolved by the host's `Runtime` at load time, not by
+  the system linker.
+- An `extern "C" { ... }` block is a normal linker-resolved C symbol
+  (`sqrt`, `malloc`, libc, etc.) — resolved at Codira's own link step, not by
+  the embedding host.
+- `@export("C")` is how a Codira function becomes callable *from* C/C++
+  (unmangled, C calling convention) — this is the mechanism
+  `codira_runtime`/`codira_runtime_capi` themselves use to expose the runtime to
+  C, generalized to any function you mark this way.
+- `extern "C++"` blocks parse identically to `extern "C"` today; C++'s lack
+  of a stable cross-compiler name-mangling scheme means proper mangled-name
+  metadata for this block is **designed but not implemented yet** — don't
+  rely on calling a real C++ (as opposed to `extern "C"`-declared) symbol
+  this way until that lands.
+- `RawPointer[T]` is the escape hatch for anything without a `Marshal`
+  impl (raw buffers, C strings, etc.) — no GC/bounds-checking on that
+  pointer, by design, the same way `unsafe` boundaries work in any other
+  safe language with C interop.
+
+---
+
+## 7. Minimal end-to-end checklist for a new embedding
+
+1. `codira new my_project/codira` (or `codira init` inside an existing
+   `codira/` subdirectory) — write the Codira side using
+   `spec/LANGUAGE_SPEC.md` §1-§11 syntax (§0 above), not any `examples/**`
+   file's syntax.
+2. Declare every function the host must call as `public func`. Declare every
+   function the host must implement as `extern func name(...) -> T;`.
+3. On the host side, add a dependency on `codira_runtime` (Rust) or link
+   against `codira_runtime_capi`/use the `cpp/include/codira` headers (C/C++).
+4. Build the Codira runtime handle: `Runtime::builder(path)` →
+   `.insert_fn(...)` for every `extern` → `unsafe { .finish() }`.
+5. Call in with `runtime.invoke::<Ret, Args>("name", args)`; for anything
+   that returns a `struct`/`class`, immediately `.root()` it if you need to
+   keep it past this call.
+6. If you want hot reload, start the compiler with `codira build --watch
+   --manifest-path=<path to codira.toml>` and call `unsafe {
+   runtime.update() }` once per host tick.
+7. Verify by actually running both processes side by side — this is
+   integration behavior no `cargo check`/type-checker can confirm for you.
+
+Happy embedding!

--- a/agents/RUST_TO_CODIRA_MIGRATION.md
+++ b/agents/RUST_TO_CODIRA_MIGRATION.md
@@ -1,0 +1,510 @@
+<!--
+Copyright (c) 2026 Omnira CJSC
+Author: Tunjay Akbarli
+Date: August 13, 2026
+
+Functionality: Instructions for AI coding agents — how to migrate/port Rust
+source code to Codira, including an honest account of which parts of the
+target language are actually execution-verified versus parse-only today.
+-->
+
+# Rust → Codira Migration Guide — Agent Instructions
+
+This document is for an agent asked to **port or translate Rust code into
+Codira**. Read `USING_CODIRA.md` first for the baseline language tutorial;
+this document is a delta focused specifically on *"here's the Rust idiom,
+here's the Codira equivalent, here's whether it actually runs today."*
+
+> **Ground truth and verification method.** Every claim below was checked on
+> 2026-08-13 against `spec/LANGUAGE_SPEC.md`, the exhaustive
+> "Implementation status" §12 of that spec, `crates/codira_syntax/**`,
+> `crates/codira_project/src/manifest/toml.rs` (the `codira.toml` schema),
+> `crates/codira/src/lib.rs` (the actual CLI command list), and `std/**`
+> (read directly, not assumed). Where the language *design* (what
+> `LANGUAGE_SPEC.md` describes) and the *current compiler* (what actually
+> parses/lowers/runs) diverge, both are stated explicitly — Rust engineers
+> reflexively reach for pattern matching, `Result`, traits, and closures,
+> and **most of those do not execute correctly in Codira yet**, even though
+> they're valid syntax that appears to parse.
+
+---
+
+## 0. The two-tier reality check (read this first)
+
+Codira's syntax layer (parser) is far ahead of its semantic layer (HIR
+lowering/codegen). `spec/LANGUAGE_SPEC.md` §12 draws an explicit line
+between:
+
+**Tier 1 — verified end-to-end (parser → HIR → LLVM → link → run):**
+`struct`, `class`, `func`, `let`/`var`, field access, arithmetic,
+comparisons, `if`/`else`, `for`/`while` loops, function calls, `import`s and
+visibility (`public`/`internal`/`private`), and `extern`-function host
+interop (see `EMBEDDING_CODIRA.md`).
+
+**Tier 2 — parses into a correct syntax tree, but is not yet lowered to
+runnable code** (an `enum` type won't resolve in a signature; `match`
+expressions lower to a `Missing` HIR placeholder so surrounding code still
+type-checks, but the match itself doesn't execute correctly):
+`enum`, `trait`, `match`, `effect`/`uses`/`perform`/`handle`/`resume`,
+`comptime` (currently just runs its body at normal runtime — "transparently
+lowered to their inner block in HIR for now", i.e. it does **not** yet
+guarantee compile-time evaluation despite the name), generics (`[T]`
+verified only at the parser level — the full-stack capstone test in spec
+§12 that actually built→linked→ran never exercised a generic function),
+multiple-dispatch/function-overloading (**actively rejected** by the
+compiler today — defining two functions with the same name is a compile
+error, "a value named `combine` has already been defined in this module"),
+`Type.method()` associated/static-function call syntax (no working call
+site exists — `Point.new(...)` does not resolve), `Type?` optionals and `!`
+force-unwrap (both parse; `Type?` lowers *transparently to its base type*
+with **no compile-time nil-safety enforced**, and `!` lowers to the same
+`Missing` placeholder as `match`), refinement types, and `supervisor`.
+
+**When porting Rust code, default every design decision toward Tier 1.**
+Where Rust idiomatically needs a Tier-2 feature (pattern matching, `Result`,
+trait objects, generics), this guide gives you the closest working Tier-1
+substitute plus the "correct" Tier-2 code to leave as a comment/TODO for
+when that feature lands — see §9.
+
+Corroborating evidence this isn't theoretical: `std/testing/testing.code`
+(this repo's own standard library) declares two functions both named
+`assert_true` with different parameter lists — exactly the overload pattern
+the compiler currently rejects. Treat **all** of `std/**` as design
+reference, not working code, until you've personally verified a given
+module compiles (see `EMBEDDING_CODIRA.md` §0 for the parallel warning about
+`examples/**`).
+
+---
+
+## 1. Keyword and punctuation mapping
+
+| Rust | Codira | Notes |
+|---|---|---|
+| `fn` | `func` | |
+| `pub` | `public` | Codira adds `internal` (package-wide) between `private` (default) and `public`; there is no `pub(crate)`/`pub(in path)` fine-grained visibility |
+| `let` | `let` | immutable, same meaning |
+| `let mut` | `var` | `var` fully replaces `let mut`; no standalone `mut` keyword anywhere (params/fields/patterns all use `var`) |
+| `impl Type { }` | `extend Type { }` | see §4 — no relation to Rust's trait-impl; `struct`/`class` bodies hold **fields only**, all methods/`init` live in `extend` |
+| `trait Name { }` | `trait Name { }` | same spelling, Tier 2 (parses, not resolved) |
+| `use a::b;` | `import a.b` | `;` optional |
+| `mod foo;` / file-based modules | file-based modules | same concept: one file = one module, directories nest modules |
+| `::` path separator | `.` | one operator for modules, types, and values (Python/Swift-style) |
+| `crate::foo` / `self::foo` (from crate root) | `root.foo` | `root` = package root |
+| `<T>` generics, turbofish `foo::<T>()` | `[T]` generics, **no turbofish** | type args only in type position / static member access; ordinary calls always infer |
+| `#[derive(...)]`, `#[attr]` | `@derive(...)`, `@name(...)` | decorator-style, above the item |
+| `macro_rules!` / proc-macros | `macro name(...) { }` | operates on the item's syntax tree at `comptime`, no textual token-pasting |
+| `&T`, `&mut T`, lifetimes `'a` | **none** | no borrow checker at all — see §3 |
+| `Option<T>` | `T?` (sugar) + `std/collections/optional.code` (Tier 2) | not compiler-enforced yet — see §8 |
+| `Result<T, E>`, `?` operator | no language builtin; `std/builtin/error.code`'s `Error` struct convention | no `?`-propagation operator exists in the grammar — see §8 |
+| `match` | `match` | same shape, Tier 2 |
+| `enum` | `enum` | same shape (labeled-tuple variants), Tier 2 |
+| closures `\|x\| x + 1`, `Fn`/`FnMut`/`FnOnce` | **no equivalent found** | see §7 |
+| `dyn Trait`, trait objects | `trait` conformance + `class` inheritance | dispatch mechanism designed (§5) but not lowered yet |
+| `async`/`await`, threads, `Send`/`Sync` | **no evidence found in the grammar or parser** | do not port concurrent Rust code expecting a Codira equivalent to exist |
+| `Drop` trait / destructors | **no evidence found** | no RAII-on-scope-exit mechanism documented |
+| `Rc<T>`/`Arc<T>`/`Box<T>` | `class` (GC reference type) | Codira's GC already gives you shared, aliasable ownership — you generally don't need an explicit smart pointer |
+| `RefCell`/`Mutex`-style interior mutability | `var` field on a `class` | mutation through any alias is already legal for `class` instances (§3) |
+
+---
+
+## 2. Project/build system
+
+| Rust (`Cargo.toml` / `cargo`) | Codira (`codira.toml` / `codira`) |
+|---|---|
+| `[package] name/version/authors` | `[package] name/version/authors` — **identical shape**, but this is *all* `codira.toml` currently supports (`crates/codira_project/src/manifest/toml.rs`: `TomlProject { name, version, authors }`, nothing else) |
+| `[dependencies]`, crates.io | **no equivalent exists yet.** There is no dependency section in the manifest schema and no package registry. A Codira package today is a single, self-contained module tree — plan ports as one package, not a multi-crate workspace, until dependency support exists |
+| `cargo new`/`cargo init` | `codira new <path>` / `codira init [path]` |
+| `cargo build` | `codira build` (`-O 0..3`, `--emit-ir`, `--watch`, `--target <triple>`, `--manifest-path <path>`, `--color`) |
+| `cargo run` | **no `codira run`.** Build then `codira start <lib> [entry]`, which only supports entry points returning `bool`/`f64`/`i64`/`()` |
+| `cargo test` | **no `codira test` subcommand.** The CLI's full command list (`crates/codira/src/lib.rs`) is exactly `language-server`, `build`, `new`, `init`, `start` — nothing else. A `codira_test` crate exists in this workspace but is not wired to a user-facing CLI command; `std/testing/testing.code` provides `assert_*` helpers you can call manually from `main`, and `@test` is listed in the spec as a planned built-in attribute, but there is no `codira test` runner today |
+| `src/main.rs` binary | Codira produces **libraries only** (`target/<name>.codiralib`), never a standalone OS executable — see `EMBEDDING_CODIRA.md` for how something else (a Rust/C/C++ host, or `codira start` itself) drives it |
+| `src/lib.rs` + `mod` tree | `src/mod.code` + nested directories — same one-file-one-module philosophy Rust uses, just a different file extension (`.code`) and root file name |
+| `rustc --edition`, editions | no equivalent found — treat the language as a single, currently-evolving surface (the "Next Generation Syntax" redesign in `spec/LANGUAGE_SPEC.md` **is** the only surface; there is no edition flag to opt into old vs. new syntax) |
+
+---
+
+## 3. Ownership, mutability, and aliasing — the biggest mental-model shift
+
+This is the change that will break the most Rust intuition. Codira
+**deliberately has no borrow checker, no lifetimes, and no `&`/`&mut`
+anywhere in the grammar** (`spec/LANGUAGE_SPEC.md` §8, titled exactly for
+this reason). Instead:
+
+- `struct` = value type. Copied on assignment/pass, exactly like a Rust
+  type that is `Copy` (or that you'd `.clone()` everywhere) — no aliasing
+  is possible by construction, so there's nothing to borrow-check.
+- `class` = GC-managed reference type. Any number of `let`/`var` bindings
+  can alias the same instance; mutation through one binding is visible
+  through all of them — the same mental model as `Rc<RefCell<T>>` in Rust,
+  except it's the *default* behavior of `class`, not something you opt into
+  with wrapper types.
+- There is no move semantics to reason about for `struct`s (they copy) and
+  no borrow conflicts to reason about for `class`es (mutation is always
+  shared/GC-tracked). This is a **deliberate design tradeoff against**
+  Rust's model, explicitly because Codira's hot-reload feature depends on
+  being able to swap a live `class`'s method implementations while keeping
+  its heap identity and fields intact — something a genuinely
+  borrow-checked, static-stack-layout region cannot support.
+- `consuming`/`borrowing` parameter-position keywords exist in the grammar
+  (Mojo/Swift-inspired scaffolding, `spec/LANGUAGE_SPEC.md` §14) and a `~Trait`
+  inheritance-list opt-out (e.g. `struct GPUBuffer: ~Copyable {}`) for
+  marking a type as a non-duplicable resource — but **neither is enforced**.
+  A `consuming` parameter doesn't actually invalidate the caller's binding,
+  and there is no `Copyable` marker trait yet to opt out of. Don't rely on
+  either for actual move/ownership safety; they currently only communicate
+  intent.
+
+**Porting rule:** a Rust `struct` with no `Rc`/`RefCell`/interior mutability
+→ Codira `struct`. A Rust type wrapped in `Rc<RefCell<T>>`, `Arc<Mutex<T>>`,
+or anything relying on shared mutable state → Codira `class`. If a Rust
+function takes `&mut self` to mutate through a shared reference, the direct
+translation is a `class` method (`func f(var self, ...)`); if it takes
+`&self`, translate to an ordinary `class` or `struct` method with a
+non-`var` `self`.
+
+---
+
+## 4. Structs, methods, and `init`
+
+Rust:
+
+```rust
+struct Point { x: f64, y: f64 }
+
+impl Point {
+    fn new(x: f64, y: f64) -> Self {
+        Point { x, y }
+    }
+
+    fn distance_squared(&self, other: &Point) -> f64 {
+        let dx = self.x - other.x;
+        let dy = self.y - other.y;
+        dx * dx + dy * dy
+    }
+}
+```
+
+Codira (Tier 1 — verified working, modulo §0's note that `Point.new(...)`
+associated-call syntax doesn't resolve — see the caption below):
+
+```codira
+struct Point {
+    x: f64
+    y: f64
+}
+
+extend Point {
+    init(x: f64, y: f64) {
+        self.x = x
+        self.y = y
+    }
+
+    func distance_squared(self, other: Point) -> f64 {
+        let dx = self.x - other.x
+        let dy = self.y - other.y
+        dx * dx + dy * dy
+    }
+}
+```
+
+Key differences from Rust's `impl` block:
+
+- `struct`/`class` bodies hold **fields only** (no trailing commas needed,
+  newline-separated). All behavior — `init`, instance methods, `override`s
+  — goes in a separate `extend Type { }` block. You cannot mix fields and
+  methods in one block the way Rust's `struct` + `impl` conceptually can
+  feel merged.
+- There is no `Self` type alias in the examples the spec shows — spell the
+  type name out (`Point`, not `Self`).
+- `init` replaces both Rust's conventional `fn new(...) -> Self` **and**
+  struct-literal-with-explicit-fields — but unlike Rust, you cannot call it
+  as `Point.new(...)` or `Point.init(...)`; **there is currently no working
+  syntax to invoke a static/associated function at all** (§0, Tier 2). Two
+  practical workarounds while porting:
+  1. Prefer a plain top-level function (`func new_point(x: f64, y: f64) ->
+     Point { Point { x: x, y: y } }`) over an `init`-only constructor when
+     you need to actually construct instances from other code today.
+  2. For a `class`, `init` **is** reachable, just not through `Type.method()`
+     call syntax — the runtime-facing capstone example in spec §12
+     constructs a plain `struct` via a struct literal (`Point { x: 3.0, y:
+     4.0 }`), not via `init`; treat direct struct-literal construction as
+     the Tier-1-verified path, and treat `extend`-block `init`/methods as
+     verified for **instance methods on an already-constructed value**
+     (`p.distance_squared(other)`), not for construction itself.
+- Mutability of `self` in a method mirrors Rust's `&self` vs `&mut self`
+  split, but spelled as a keyword on the parameter itself:
+  `func take_damage(var self, amount: f64)` (mutating) vs.
+  `func area(self) -> f64` (read-only) — no `&`/`&mut` prefix, ever.
+
+---
+
+## 5. Enums, pattern matching, and traits (Tier 2 — don't rely on these executing)
+
+Rust:
+
+```rust
+enum Shape {
+    Circle { radius: f64 },
+    Rectangle { width: f64, height: f64 },
+}
+
+fn area(shape: &Shape) -> f64 {
+    match shape {
+        Shape::Circle { radius } => std::f64::consts::PI * radius * radius,
+        Shape::Rectangle { width, height } => width * height,
+    }
+}
+```
+
+The syntactically-corresponding Codira (this **parses** but the `match`
+lowers to a `Missing` HIR placeholder — do not port working logic this way
+today):
+
+```codira
+enum Shape {
+    Circle(radius: f64)
+    Rectangle(width: f64, height: f64)
+}
+
+func area(shape: Shape) -> f64 {
+    match shape {
+        Shape.Circle(radius) -> 3.14159 * radius * radius
+        Shape.Rectangle(width, height) -> width * height
+    }
+}
+```
+
+**Practical porting strategy for a Rust `enum` + `match`:** until enums are
+lowered, model the same domain with a Tier-1 substitute:
+
+- A small, closed set of variants with no payload → distinct `bool`/`i32`
+  "tag" comparisons with `if`/`else if`, or (if the set is genuinely fixed
+  and small) one `struct`/`class` per variant plus separate handling
+  functions.
+- Variants that each carry different data (a Rust "sum type") → a `struct`
+  with one field per possible payload plus a discriminant field you check
+  by hand, or split into one function per case called directly by whatever
+  produced the enum value in Rust. This is less elegant than Rust's `enum`,
+  but it is what actually runs today.
+- Keep the "correct" `enum`/`match` version around as a comment so the code
+  is a trivial rewrite once enums are lowered — don't delete the intent.
+
+**Traits.** `trait Name { }` and `extend Type: Trait { }` parse, including
+default method bodies, `class` single inheritance, mandatory `override`,
+and a designed multiple-dispatch/runtime-type-tag fallback for trait-typed
+parameters (`spec/LANGUAGE_SPEC.md` §5) — but per §12, `trait` items are not
+yet lowered into name-resolvable HIR items, so a `Type` named only by a
+trait bound won't resolve in a signature, and the "most-specific-applicable
+method" resolution rule for multiple dispatch is explicitly **not
+implemented** (`method_resolution.rs`). **Function overloading itself is
+actively rejected** — you cannot even declare two functions with the same
+name and different parameter types today (confirmed both by the spec's
+capstone-verification notes and by `std/testing/testing.code` shipping code
+that would hit exactly this error). Port Rust trait-object-polymorphism to
+distinctly-named Codira functions per concrete type for now (e.g.
+`circle_area(c: Circle)` / `rectangle_area(r: Rectangle)` instead of a
+shared `area()` overload set or a `dyn Shape`).
+
+---
+
+## 6. Optionals and error handling
+
+Rust `Option<T>`/`Result<T, E>` + `?` have **no directly working Codira
+equivalent** yet:
+
+- `Type?` is valid Codira syntax (`if let value = find(xs, 7) { ... }`,
+  `find(xs, 7)!` to force-unwrap) and is the *designed* replacement for
+  `Option<T>` — but per §12, `Type?` **lowers transparently to its base
+  type**, so nothing is statically enforced about nullability today, and
+  `!` force-unwrap lowers to the same `Missing` HIR placeholder `match`
+  does. Treat `Type?` as a documentation-only convention right now, not a
+  safety guarantee.
+- There is **no `Result<T, E>` in the language** and **no `?`-propagation
+  operator** in the grammar at all. `std/builtin/error.code`'s `Error`
+  struct (message + numeric code) plus a documented "functions that can
+  fail return `Result[T, Error]`" *convention* is aspirational — it
+  references a generic `Result[T, Error]` type that does not exist anywhere
+  else in `std/` or the spec, and the `?`-propagation comment in that same
+  file describes an operator that isn't in the grammar. Don't port Rust's
+  `?`-heavy error-propagation style expecting it to compile.
+- **Practical porting strategy:** for fallible Rust functions, return a
+  sentinel value (a documented "impossible" value, e.g. `-1.0` for a
+  distance function, or a separate `bool`/status `out`-parameter pattern),
+  or return a `struct` with an explicit `ok: bool` field plus the payload,
+  and check it explicitly at every call site with `if`. This is more
+  verbose than idiomatic Rust but is Tier-1 (plain structs + `if`), so it
+  actually runs.
+- Rust `panic!`/`.unwrap()`/`.expect(...)` → the spec documents that
+  bounds-checked array indexing and (once implemented) `!` force-unwrap
+  should produce "a recoverable panic with source location" — but this is
+  design intent from §7, not confirmed in the Tier-1 verified list. Don't
+  assume a panic path is safely recoverable until you've checked it
+  directly against a build of the compiler you're targeting.
+
+---
+
+## 7. Closures, iterators, and function values
+
+**No evidence of closures, `Fn`/`FnMut`/`FnOnce`, or any first-class
+function-value/lambda syntax was found anywhere in `spec/LANGUAGE_SPEC.md`
+or the `codira_syntax` grammar.** This is a real, current gap, not a
+documentation omission — search both yourself before assuming otherwise if
+this guide is ever stale.
+
+Practical consequences when porting:
+
+- Rust iterator-chain code (`.iter().map(...).filter(...).collect()`) has
+  no direct translation. Port it to an explicit `for`/`while` loop over an
+  array (Tier 1) accumulating into a `var`-declared result.
+- Rust callback parameters (`fn register(cb: impl Fn(i32))`) have no
+  Codira equivalent as ordinary in-language function values. The only
+  place a "function pointer" concept exists at all is the **host-embedding
+  boundary** — `extern func name(...) -> T;` plus a host-supplied
+  `extern "C" fn` (see `EMBEDDING_CODIRA.md` §3.3) — which is a
+  cross-language FFI mechanism, not a general Codira closure type. Model
+  callback-shaped Rust code as either (a) inline logic instead of an
+  injected function, or (b) an `extern`-declared hook if the "callback" is
+  genuinely meant to be supplied by the host application.
+- Algebraic effects (`effect`/`uses`/`perform`/`handle`/`resume`, §6 of the
+  spec) are explicitly *designed* to cover some of what Rust would use
+  closures/dependency-injection/`Result`-based error handling for (logging,
+  failure, DI-style effects) — but per §0 this is Tier 2 (parses only, not
+  lowered), so don't reach for it as a working substitute today either.
+
+---
+
+## 8. Generics
+
+Rust `Vec<T>`/`HashMap<K, V>`/`fn max<T: PartialOrd>(a: T, b: T) -> T` →
+Codira uses square brackets (`Box[T]`, `func max[T](a: T, b: T) -> T where
+T: Comparable`), never angle brackets, and **there is no turbofish** —
+explicit type arguments are only legal in type position and static member
+access, never at an ordinary call site (arguments are always inferred).
+
+Status: generics are listed among the constructs with **63 passing
+lexer/parser tests**, but the full build→link→run capstone verification in
+spec §12 exercised only non-generic `struct`/`func`/`let`/arithmetic code —
+it did not exercise a generic function or type end-to-end. Treat generics
+as **unverified at the codegen/runtime level** even though they parse
+correctly; if you port a generic Rust function, expect to need a
+non-generic (monomorphized-by-hand, one function per concrete type)
+fallback if the generic version doesn't actually build.
+
+---
+
+## 9. Worked example: porting a small Rust module
+
+Rust:
+
+```rust
+pub struct Inventory {
+    items: Vec<Item>,
+}
+
+pub struct Item {
+    pub name: String,
+    pub quantity: u32,
+}
+
+impl Inventory {
+    pub fn new() -> Self {
+        Inventory { items: Vec::new() }
+    }
+
+    pub fn total_quantity(&self) -> u32 {
+        self.items.iter().map(|i| i.quantity).sum()
+    }
+
+    pub fn find(&self, name: &str) -> Option<&Item> {
+        self.items.iter().find(|i| i.name == name)
+    }
+}
+```
+
+Codira port, written to match what's actually Tier-1-verified today (no
+`enum`/`match`/`Option`/closures/iterator chains/associated `new()`):
+
+```codira
+public struct Item {
+    name: String
+    quantity: u32
+}
+
+public struct Inventory {
+    items: [Item]
+}
+
+// Constructor: plain top-level function, not Type.new() (§4 — associated
+// call syntax doesn't resolve yet). Caller does `new_inventory(some_items)`.
+public func new_inventory(items: [Item]) -> Inventory {
+    Inventory { items: items }
+}
+
+// No .iter().map().sum() — explicit loop instead (§7: no iterator chains).
+public func total_quantity(inv: Inventory) -> u32 {
+    var total = 0u32
+    for item in inv.items {
+        total += item.quantity
+    }
+    total
+}
+
+// No Option<&Item> — explicit "found" flag instead of Type? (§6: Type?
+// isn't enforced, and there's no clean way to express "no item" as a
+// first-class value yet without enum support). Caller must check `found`
+// before trusting `item`.
+public struct FindResult {
+    found: bool
+    item: Item
+}
+
+public func find_item(inv: Inventory, name: String) -> FindResult {
+    for item in inv.items {
+        if item.name == name {
+            return FindResult { found: true, item: item }
+        }
+    }
+    FindResult { found: false, item: Item { name: "", quantity: 0 } }
+}
+```
+
+Note everything above only uses Tier-1 constructs (`struct`, `func`,
+`let`/`var`, `for`, `if`, arithmetic, array type `[T]`, struct literals) —
+this is code an agent can actually expect to compile and run today, not
+just parse.
+
+---
+
+## 10. Migration readiness checklist
+
+Good candidates to port to Codira **today**:
+
+- Plain-old-data-heavy simulation/gameplay state (structs of numbers/bools,
+  updated every frame) — this is exactly what `examples/buoyancy` and
+  `examples/rust-pong`'s Codira side model, and it's squarely Tier 1.
+- Straight-line numeric/algorithmic code (no enums, traits, or closures) —
+  translates almost mechanically per §1's keyword table.
+- Code that already treats "fallible" as "return a sentinel/flag", not
+  `Result`/`?`-heavy code.
+
+Poor candidates until the relevant Tier-2 gaps close — port these last, or
+keep them on the host (Rust) side and only expose thin Tier-1 Codira
+surface via `extern`/`@export("C")` (`EMBEDDING_CODIRA.md` §6):
+
+- Anything built around `enum` + `match` as the primary control structure.
+- Trait-object/`dyn`-heavy polymorphism, or any reliance on function
+  overloading.
+- `Result`/`?`-based error propagation.
+- Iterator-chain-heavy code, or anything passing closures/callbacks as
+  values within the language itself.
+- Generic-heavy libraries (verify generics work for your specific case
+  before committing to a large generic-based port).
+- Anything concurrent (threads, `async`/`await`, channels) — no evidence
+  any of this exists yet beyond the unenforced `spawn <expr>` keyword
+  scaffold in spec §14.
+
+When in doubt, write the smallest Tier-1 version first and confirm it with
+a real `codira build` (and, if embedding, `codira start`/a host `invoke`
+call per `EMBEDDING_CODIRA.md`) before trusting the port — this document
+describes what should work, not a substitute for actually running the
+compiler.

--- a/agents/USING_CODIRA.md
+++ b/agents/USING_CODIRA.md
@@ -1,0 +1,278 @@
+<!--
+Copyright (c) 2026 Omnira CJSC
+Author: Tunjay Akbarli
+Date: August 6, 2026
+
+Functionality: Instructions for AI coding agents — how to USE the Codira
+programming language to write projects (NOT how to build the compiler).
+ -->
+
+# Using Codira — Agent Instructions
+
+This document teaches an AI coding agent how to **use** the Codira programming
+language to write and run programs. It is *not* about building the compiler;
+for compiler-internals work see `spec/LANGUAGE_SPEC.md` §12-§15 and the
+`crates/**` sources.
+
+Codira is an ahead-of-time (AOT) compiled, statically typed, hot-reloadable
+systems language with an LLVM backend. It compiles to natively executable
+machine code, cross-compiles, and ships as reusable libraries.
+
+> **Ground truth** — Language details change fast. Always prefer
+> `spec/LANGUAGE_SPEC.md` over this guide when they disagree. This guide is a
+> friendly summary of the current (v26.8.1) surface.
+
+---
+
+## 1. What Codira is not
+
+- No `null` / undefined reference value. Absence is spelled `Type?` and handled
+  explicitly.
+- No template angle brackets — generics use **square brackets** `[T]`.
+- `;` is *optional* at the end of a line-terminated statement. The parser is
+  not indentation-sensitive; it just treats `;` as always-legal.
+- No borrow checker / ownership model. `struct` = value (copied on pass),
+  `class` = GC-managed reference (shared mutability).
+- No standalone executable by default — you produce a Codira "library"
+  (`*.codiralib`) and run it via the `codira start` CLI.
+
+---
+
+## 2. Project layout
+
+A Codira project is a directory holding the source plus a manifest. Example:
+
+```
+my_program/
+├── src/
+│   └── mod.code      # module source (must end in `.code`)
+└── codira.toml       # manifest
+```
+
+- Source files always end in **`.code`**. Multi-word file names use
+  underscores. One file = one module; directories nest modules.
+- The manifest (`codira.toml`) declares package metadata:
+  ```toml
+  [package]
+  name="my_program"
+  authors=[]
+  version="0.1.0"
+  ```
+- Compiling yields `target/mod.codiralib`; `codira start` invokes a chosen
+  entry-point function.
+
+### Scaffold a project
+
+```bash
+codira new my_program      # creates a new directory + project
+codira init .             # initializes the current directory (or [path])
+```
+
+The generated `src/mod.code` starts as:
+
+```
+public func main() -> f64 {
+    3.14159
+}
+```
+
+---
+
+## 3. Writing Codira source
+
+### Lexical rules
+
+Full reserved keyword list (the modern, non-Rust surface):
+
+```
+as break class comptime effect else enum extend extern false for
+func handle if import in init internal let loop macro match never
+nil override perform private public resume return root self static
+struct super true trait uses var where while
+```
+
+The path separator is **`.`** (like Python/Swift), not `::`.
+
+### Functions
+
+```codira
+func add(a: i32, b: i32) -> i32 {
+    a + b
+}
+```
+
+Visibility: `private` (default — write nothing), `internal` (same package),
+`public` (exported):
+
+```codira
+public func distance_squared(a: Point, b: Point) -> f64 {
+    let dx = a.x - b.x
+    let dy = a.y - b.y
+    dx * dx + dy * dy
+}
+```
+
+Implicit return — the last expression is the return value; `return x` also works.
+
+### Bindings
+
+```codira
+let pi = 3.14159     // immutable
+var counter = 0       // mutable
+counter += 1
+```
+
+`var` replaces `let mut`; there is no standalone `mut` keyword.
+
+### Records (value) vs classes (reference)
+
+```codira
+// Value type: copied on assignment/pass, value semantics.
+struct Point {
+    x: f64
+    y: f64
+}
+
+// Reference type: heap-allocated, garbage collected, shared mutability.
+class Actor {
+    var position: Point
+    var health: f64
+}
+```
+
+### Methods via `extend` (was `impl`)
+
+The type body holds **fields only**; methods and `init` live in an `extend` block:
+
+```codira
+extend Actor {
+    init(position: Point) {
+        self.position = position
+    }
+    func take_damage(var self, amount: f64) {
+        self.health -= amount
+    }
+}
+```
+
+### Enums & pattern matching
+
+```codira
+enum Shape {
+    Circle(radius: f64)
+    Rectangle(width: f64, height: f64)
+}
+
+func area(shape: Shape) -> f64 {
+    match shape {
+        Shape.Circle(radius) -> 3.14159 * radius * radius
+        Shape.Rectangle(width, height) -> width * height
+    }
+}
+```
+
+`match` must be exhaustive (or include a `_` wildcard arm).
+
+### Generics
+
+```codira
+struct Box[T] {
+    value: T
+}
+
+func first[T](items: [T]) -> T? {
+    if items.is_empty() { nil } else { items[0] }
+}
+```
+
+### Optional types
+
+```codira
+func find(items: [Value], target: i32) -> i32? {
+    for item in items {
+        if item == target { return item }
+    }
+    nil
+}
+
+if let value = find(xs, 7) {
+    print(value)
+}
+```
+
+### Modules & imports
+
+```codira
+import math
+import collections.list
+import geometry.{ Point, Vector as Vec2 }
+
+root.tools.clamp(x, 0, 1)     // `root` = package root
+super.helper()                 // parent module
+```
+
+---
+
+## 4. Building and running
+
+```bash
+codira build                                     # compile -> target/mod.codiralib
+codira start target/mod.codiralib main          # run entry function `main`
+```
+
+`codira start` prints the entry point's return value when its type is `bool`,
+`f64`, `i64`, or `()`.
+
+Useful `build` options: `-O 0..3` (default `2`), `--emit-ir`, `--watch`,
+`--target <triple>` (cross-compile), `--manifest-path <path>`.
+
+Hot reload: Codira is designed so a running application can swap function
+bodies without a manual stop/restart cycle.
+
+---
+
+## 5. End-to-end status today
+
+Verified through the full pipeline (parser → HIR → LLVM → link → run):
+
+- `struct`, `class`, `func`, `let`/`var`
+- field access, arithmetic, comparisons
+- `if`/`else`, `for`/`while` loops, function calls
+- imports and visibility (`public`/`internal`/`private`)
+
+Parsed to a real syntax tree but **not yet lowered** to runnable code
+(HIR `Missing` placeholder): `enum`, `trait`, `effect`/`handle`, `match`,
+`comptime`, `supervisor`, multiple dispatch, and `Type.method()` associated
+call syntax.
+
+---
+
+## 6. Reference material (in this repository)
+
+- `spec/LANGUAGE_SPEC.md` — the canonical, current language spec.
+- `spec/HERACLES_Codira_Examples.code` — self-healing framework examples
+  (`@heal(...)`, refinement types, `supervisor`).
+- `book/src/**` — chapter-based tutorial (getting started, hot-reload, arrays,
+  structs).
+- `examples/**` — runnable Codira (and Rust, C++, C) example projects.
+- `std/` — the Codira standard library source (`*.code`).
+
+Always cross-check written code against `spec/LANGUAGE_SPEC.md` and the parser
+tests in `crates/codira_syntax/src/tests.rs`.
+
+---
+
+## 7. Agent coding rules
+
+1. **Use `.code` files.** Start with a single `src/mod.code`; nest modules via
+   subdirectories when a package grows.
+2. **Prefer explicit types** at module and interop boundaries (inference works
+   but less clarity).
+3. **No `null`** — design around `Type?` optionals and explicit error returns.
+4. **No `::`, no `<>`** — use `.` paths and `[T]` generics on args.
+5. **Semicolons** are optional; keep lines mostly semicolon-free unless two
+   statements share one line.
+6. **Verify** with `codira build` and `codira start` rather than guessing.
+7. When this guide and the spec disagree, **obey `spec/LANGUAGE_SPEC.md`**.
+
+Happy coding in Codira!

--- a/crates/codira_comptime/Cargo.toml
+++ b/crates/codira_comptime/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "codira_comptime"
+description = "Parametric compile-time evaluator and elaborator (monomorphizer) for codira_mir -- see spec/KGEN_SUPERSET_ARCHITECTURE.md"
+keywords = ["game", "hot-reloading", "language", "codira", "compiler"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+codira_mir = { version = "0.6.0-dev", path = "../codira_mir" }
+rustc-hash = { workspace = true, features = ["std"] }
+smol_str = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/codira_comptime/src/interp.rs
+++ b/crates/codira_comptime/src/interp.rs
@@ -1,0 +1,149 @@
+//! The compile-time interpreter.
+//!
+//! Structural analog of `KGEN/lib/Interpreter` -- evaluates a `codira_mir`
+//! [`Body`] to a concrete [`Value`], for both plain `comptime { .. }` blocks
+//! and (once wired into elaboration) generator parameter expressions. See
+//! `spec/KGEN_SUPERSET_ARCHITECTURE.md` §4.
+
+use codira_mir::{Attr, Body, Op, OpId, OpKind};
+
+use crate::value::{EvalError, Value};
+use crate::Env;
+
+/// Evaluates a [`Body`] to its result value (the value of its last op),
+/// under the given parameter bindings.
+pub fn eval_body(body: &Body, env: &Env) -> Result<Value, EvalError> {
+    let result = body.result().ok_or(EvalError::EmptyRegion)?;
+    eval_op(body, result, env)
+}
+
+fn eval_op(body: &Body, id: OpId, env: &Env) -> Result<Value, EvalError> {
+    let op: &Op = body.get(id);
+    match &op.kind {
+        OpKind::Const(attr) => eval_attr(attr, env),
+
+        OpKind::Add | OpKind::Sub | OpKind::Mul | OpKind::Div | OpKind::Rem => {
+            let (lhs, rhs) = binary_int_operands(body, op, env)?;
+            match op.kind {
+                OpKind::Add => Ok(Value::Int(lhs.wrapping_add(rhs))),
+                OpKind::Sub => Ok(Value::Int(lhs.wrapping_sub(rhs))),
+                OpKind::Mul => Ok(Value::Int(lhs.wrapping_mul(rhs))),
+                OpKind::Div => lhs
+                    .checked_div(rhs)
+                    .map(Value::Int)
+                    .ok_or(EvalError::DivideByZero),
+                OpKind::Rem => lhs
+                    .checked_rem(rhs)
+                    .map(Value::Int)
+                    .ok_or(EvalError::DivideByZero),
+                _ => unreachable!(),
+            }
+        }
+
+        OpKind::Neg => {
+            let v = unary_int_operand(body, op, env)?;
+            Ok(Value::Int(v.wrapping_neg()))
+        }
+
+        OpKind::Eq | OpKind::Ne | OpKind::Lt | OpKind::Le | OpKind::Gt | OpKind::Ge => {
+            let (lhs, rhs) = binary_int_operands(body, op, env)?;
+            Ok(Value::Bool(match op.kind {
+                OpKind::Eq => lhs == rhs,
+                OpKind::Ne => lhs != rhs,
+                OpKind::Lt => lhs < rhs,
+                OpKind::Le => lhs <= rhs,
+                OpKind::Gt => lhs > rhs,
+                OpKind::Ge => lhs >= rhs,
+                _ => unreachable!(),
+            }))
+        }
+
+        OpKind::And | OpKind::Or => {
+            let (lhs, rhs) = binary_bool_operands(body, op, env)?;
+            Ok(Value::Bool(match op.kind {
+                OpKind::And => lhs && rhs,
+                OpKind::Or => lhs || rhs,
+                _ => unreachable!(),
+            }))
+        }
+
+        OpKind::Not => {
+            let v = unary_bool_operand(body, op, env)?;
+            Ok(Value::Bool(!v))
+        }
+
+        OpKind::ParamRef(name) => env.lookup(name),
+
+        OpKind::If => {
+            let [cond_id] = op.operands.as_slice() else {
+                return Err(EvalError::MalformedIf);
+            };
+            let [then_region, else_region] = op.regions.as_slice() else {
+                return Err(EvalError::MalformedIf);
+            };
+            let cond = eval_op(body, *cond_id, env)?.as_bool()?;
+            let region = if cond { then_region } else { else_region };
+            if region.body.is_empty() {
+                Ok(Value::Unit)
+            } else {
+                eval_body(&region.body, env)
+            }
+        }
+
+        OpKind::For => Err(EvalError::UnsupportedOp("cf.for")),
+        OpKind::While => Err(EvalError::UnsupportedOp("cf.while")),
+    }
+}
+
+fn eval_attr(attr: &Attr, env: &Env) -> Result<Value, EvalError> {
+    match attr {
+        Attr::Int(v) => Ok(Value::Int(*v)),
+        Attr::Bool(v) => Ok(Value::Bool(*v)),
+        Attr::Unit => Ok(Value::Unit),
+        Attr::ParamRef(name) => env.lookup(name),
+    }
+}
+
+fn binary_int_operands(body: &Body, op: &Op, env: &Env) -> Result<(i64, i64), EvalError> {
+    let [lhs_id, rhs_id] = op.operands.as_slice() else {
+        return Err(EvalError::TypeMismatch {
+            expected: "2 operands",
+            found: "different operand count",
+        });
+    };
+    let lhs = eval_op(body, *lhs_id, env)?.as_int()?;
+    let rhs = eval_op(body, *rhs_id, env)?.as_int()?;
+    Ok((lhs, rhs))
+}
+
+fn binary_bool_operands(body: &Body, op: &Op, env: &Env) -> Result<(bool, bool), EvalError> {
+    let [lhs_id, rhs_id] = op.operands.as_slice() else {
+        return Err(EvalError::TypeMismatch {
+            expected: "2 operands",
+            found: "different operand count",
+        });
+    };
+    let lhs = eval_op(body, *lhs_id, env)?.as_bool()?;
+    let rhs = eval_op(body, *rhs_id, env)?.as_bool()?;
+    Ok((lhs, rhs))
+}
+
+fn unary_int_operand(body: &Body, op: &Op, env: &Env) -> Result<i64, EvalError> {
+    let [id] = op.operands.as_slice() else {
+        return Err(EvalError::TypeMismatch {
+            expected: "1 operand",
+            found: "different operand count",
+        });
+    };
+    eval_op(body, *id, env)?.as_int()
+}
+
+fn unary_bool_operand(body: &Body, op: &Op, env: &Env) -> Result<bool, EvalError> {
+    let [id] = op.operands.as_slice() else {
+        return Err(EvalError::TypeMismatch {
+            expected: "1 operand",
+            found: "different operand count",
+        });
+    };
+    eval_op(body, *id, env)?.as_bool()
+}

--- a/crates/codira_comptime/src/lib.rs
+++ b/crates/codira_comptime/src/lib.rs
@@ -1,0 +1,20 @@
+//! Copyright (c) 2026 Omnira CJSC
+//!
+//! `codira_comptime` -- the parametric compile-time evaluator for
+//! `codira_mir`. Structural analog of `KGEN/lib/Elaborator` +
+//! `KGEN/lib/Interpreter`. See `spec/KGEN_SUPERSET_ARCHITECTURE.md` §4.
+//!
+//! This crate currently provides the interpreter (§4 point 1: evaluating a
+//! restricted region to a concrete value). The elaborator (§4 point 2:
+//! walking the call graph and producing monomorphized `Op::Func`s, wired as
+//! a salsa query for incremental reuse per §4.1) is designed but not yet
+//! implemented -- see `spec/KGEN_SUPERSET_STATUS.md`.
+
+mod interp;
+mod value;
+
+pub use interp::eval_body;
+pub use value::{EvalError, Env, Value};
+
+#[cfg(test)]
+mod tests;

--- a/crates/codira_comptime/src/tests.rs
+++ b/crates/codira_comptime/src/tests.rs
@@ -1,0 +1,115 @@
+use codira_mir::{Attr, Body, OpKind, Region};
+
+use crate::{eval_body, EvalError, Env, Value};
+
+#[test]
+fn comptime_two_plus_two_is_four() {
+    // The literal example from spec/KGEN_SUPERSET_ARCHITECTURE.md §5:
+    // `comptime { 2 + 2 }` should evaluate to 4 at compile time.
+    let mut body = Body::new();
+    let a = body.push(OpKind::Const(Attr::Int(2)), []);
+    let b = body.push(OpKind::Const(Attr::Int(2)), []);
+    body.push(OpKind::Add, [a, b]);
+
+    let result = eval_body(&body, &Env::new()).unwrap();
+    assert_eq!(result, Value::Int(4));
+}
+
+#[test]
+fn comptime_arithmetic_precedence_via_explicit_ops() {
+    // `(3 * 4) - 5`
+    let mut body = Body::new();
+    let three = body.push(OpKind::Const(Attr::Int(3)), []);
+    let four = body.push(OpKind::Const(Attr::Int(4)), []);
+    let mul = body.push(OpKind::Mul, [three, four]);
+    let five = body.push(OpKind::Const(Attr::Int(5)), []);
+    body.push(OpKind::Sub, [mul, five]);
+
+    assert_eq!(eval_body(&body, &Env::new()).unwrap(), Value::Int(7));
+}
+
+#[test]
+fn comptime_if_picks_then_branch() {
+    // `if 1 < 2 { 10 } else { 20 }`
+    let mut body = Body::new();
+    let one = body.push(OpKind::Const(Attr::Int(1)), []);
+    let two = body.push(OpKind::Const(Attr::Int(2)), []);
+    let cond = body.push(OpKind::Lt, [one, two]);
+
+    let mut then_body = Body::new();
+    then_body.push(OpKind::Const(Attr::Int(10)), []);
+    let mut else_body = Body::new();
+    else_body.push(OpKind::Const(Attr::Int(20)), []);
+
+    body.push_with_regions(
+        OpKind::If,
+        [cond],
+        [Region::new(then_body), Region::new(else_body)],
+    );
+
+    assert_eq!(eval_body(&body, &Env::new()).unwrap(), Value::Int(10));
+}
+
+#[test]
+fn comptime_if_picks_else_branch() {
+    // `if false { 10 } else { 20 }`
+    let mut body = Body::new();
+    let cond = body.push(OpKind::Const(Attr::Bool(false)), []);
+    let mut then_body = Body::new();
+    then_body.push(OpKind::Const(Attr::Int(10)), []);
+    let mut else_body = Body::new();
+    else_body.push(OpKind::Const(Attr::Int(20)), []);
+
+    body.push_with_regions(
+        OpKind::If,
+        [cond],
+        [Region::new(then_body), Region::new(else_body)],
+    );
+
+    assert_eq!(eval_body(&body, &Env::new()).unwrap(), Value::Int(20));
+}
+
+#[test]
+fn generic_param_specialization_binds_n() {
+    // Elaborating `SIMD[f32, N]`'s hypothetical bounds-check body with N=4:
+    // `N == 4`
+    let mut body = Body::new();
+    let n_ref = body.push(OpKind::ParamRef("N".into()), []);
+    let four = body.push(OpKind::Const(Attr::Int(4)), []);
+    body.push(OpKind::Eq, [n_ref, four]);
+
+    let mut env = Env::new();
+    env.bind("N", Value::Int(4));
+
+    assert_eq!(eval_body(&body, &env).unwrap(), Value::Bool(true));
+}
+
+#[test]
+fn unbound_param_ref_is_a_clean_error_not_a_panic() {
+    let mut body = Body::new();
+    body.push(OpKind::ParamRef("T".into()), []);
+
+    let err = eval_body(&body, &Env::new()).unwrap_err();
+    assert_eq!(err, EvalError::UnresolvedParam("T".into()));
+}
+
+#[test]
+fn division_by_zero_is_a_clean_error_not_a_panic() {
+    let mut body = Body::new();
+    let one = body.push(OpKind::Const(Attr::Int(1)), []);
+    let zero = body.push(OpKind::Const(Attr::Int(0)), []);
+    body.push(OpKind::Div, [one, zero]);
+
+    assert_eq!(eval_body(&body, &Env::new()).unwrap_err(), EvalError::DivideByZero);
+}
+
+#[test]
+fn loops_are_honestly_unsupported_not_silently_wrong() {
+    let mut body = Body::new();
+    body.push_with_regions(OpKind::For, [], []);
+
+    assert_eq!(
+        eval_body(&body, &Env::new()).unwrap_err(),
+        EvalError::UnsupportedOp("cf.for")
+    );
+}

--- a/crates/codira_comptime/src/value.rs
+++ b/crates/codira_comptime/src/value.rs
@@ -1,0 +1,96 @@
+//! Concrete compile-time values and the evaluation environment.
+
+use rustc_hash::FxHashMap;
+use smol_str::SmolStr;
+
+/// A concrete value produced by interpreting a `codira_mir` region.
+///
+/// Distinct from `codira_mir::Attr`: an `Attr` may still contain an
+/// unresolved `ParamRef`; a `Value` is always fully concrete. Elaboration
+/// (see `Env`) is exactly the process of turning `Attr`s into `Value`s.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Value {
+    Int(i64),
+    Bool(bool),
+    Unit,
+}
+
+impl Value {
+    pub fn type_name(self) -> &'static str {
+        match self {
+            Value::Int(_) => "int",
+            Value::Bool(_) => "bool",
+            Value::Unit => "unit",
+        }
+    }
+
+    pub fn as_int(self) -> Result<i64, EvalError> {
+        match self {
+            Value::Int(v) => Ok(v),
+            other => Err(EvalError::TypeMismatch {
+                expected: "int",
+                found: other.type_name(),
+            }),
+        }
+    }
+
+    pub fn as_bool(self) -> Result<bool, EvalError> {
+        match self {
+            Value::Bool(v) => Ok(v),
+            other => Err(EvalError::TypeMismatch {
+                expected: "bool",
+                found: other.type_name(),
+            }),
+        }
+    }
+}
+
+/// Bindings for `param.ref`/`ParamRef` names during elaboration -- e.g. `N
+/// -> Value::Int(4)` when elaborating `SIMD[f32, 4]`'s generator with `N`
+/// bound to `4`. Empty for plain `comptime { .. }` blocks, which reference
+/// no generator parameters.
+#[derive(Debug, Clone, Default)]
+pub struct Env {
+    bindings: FxHashMap<SmolStr, Value>,
+}
+
+impl Env {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn bind(&mut self, name: impl Into<SmolStr>, value: Value) -> &mut Self {
+        self.bindings.insert(name.into(), value);
+        self
+    }
+
+    pub fn lookup(&self, name: &str) -> Result<Value, EvalError> {
+        self.bindings
+            .get(name)
+            .copied()
+            .ok_or_else(|| EvalError::UnresolvedParam(name.into()))
+    }
+}
+
+/// Everything that can go wrong evaluating a `codira_mir` region at compile
+/// time. Deliberately does not have a catch-all `Other(String)` variant --
+/// every failure mode this interpreter can hit is enumerated, so callers
+/// (and tests) can match exhaustively instead of string-matching messages.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum EvalError {
+    #[error("type mismatch: expected {expected}, found {found}")]
+    TypeMismatch {
+        expected: &'static str,
+        found: &'static str,
+    },
+    #[error("unresolved parameter reference: {0}")]
+    UnresolvedParam(SmolStr),
+    #[error("division by zero")]
+    DivideByZero,
+    #[error("empty region has no result value")]
+    EmptyRegion,
+    #[error("`cf.if` requires exactly one condition operand and two regions (then, else)")]
+    MalformedIf,
+    #[error("{0} is not yet interpreted -- see spec/KGEN_SUPERSET_STATUS.md")]
+    UnsupportedOp(&'static str),
+}

--- a/crates/codira_hir/Cargo.toml
+++ b/crates/codira_hir/Cargo.toml
@@ -18,6 +18,8 @@ codira_syntax = { version = "0.6.0-dev", path = "../codira_syntax" }
 codira_target = { version = "0.6.0-dev", path = "../codira_target" }
 codira_paths = { version = "0.6.0-dev", path="../codira_paths" }
 codira_hir_input = { version = "0.6.0-dev", path="../codira_hir_input" }
+codira_mir = { version = "0.6.0-dev", path = "../codira_mir" }
+codira_comptime = { version = "0.6.0-dev", path = "../codira_comptime" }
 drop_bomb = { workspace = true }
 either = { workspace = true }
 ena = { workspace = true }

--- a/crates/codira_hir/src/comptime_fold.rs
+++ b/crates/codira_hir/src/comptime_fold.rs
@@ -1,0 +1,253 @@
+//! Copyright (c) 2026 Omnira CJSC
+//!
+//! Bridges a self-contained `comptime { .. }` block's already-lowered HIR
+//! into `codira_mir`/`codira_comptime` for real compile-time evaluation.
+//!
+//! Scope (see `spec/KGEN_SUPERSET_STATUS.md`): only single-tail-expression
+//! blocks (no `let`-statements, no expression-statements) built from
+//! literals, arithmetic/comparison/logical operators, unary neg/not, and
+//! `if`/`else` fold today. Anything referencing a name (`Path`), calling a
+//! function, indexing, looping, or containing a statement bails out
+//! (`None`) and the caller leaves the block to lower exactly as it did
+//! before this module existed -- an honest, additive-only improvement:
+//! nothing that used to work stops working, and a real (if narrow) subset
+//! of `comptime` now actually evaluates at compile time instead of always
+//! running at ordinary runtime.
+
+use la_arena::Arena;
+
+use crate::expr::{
+    ArithOp, BinaryOp, CmpOp, Expr, ExprId, Literal, LiteralInt, LiteralIntKind, LogicOp,
+    Ordering, UnaryOp,
+};
+
+/// Attempts to evaluate `block` (already-lowered HIR) at compile time.
+/// `None` means "not foldable with today's restricted subset," not an
+/// error -- callers should fall back to leaving the block unevaluated.
+pub(crate) fn try_eval(exprs: &Arena<Expr>, block: ExprId) -> Option<codira_comptime::Value> {
+    let mut body = codira_mir::Body::new();
+    build_op(exprs, block, &mut body)?;
+    codira_comptime::eval_body(&body, &codira_comptime::Env::new()).ok()
+}
+
+/// Converts a concrete evaluation result back into a source `Expr`,
+/// allocating any synthetic sub-expressions (the literal inside a negative
+/// result's `UnaryOp::Neg` wrapper) into `exprs`. Returns `None` for
+/// `Value::Unit` -- there is no `Expr::Literal` variant that safely stands
+/// in for "unit" without risking a type mismatch against the block's
+/// inferred type, and it's a low-value case to special-case further today.
+pub(crate) fn value_to_expr(
+    exprs: &mut Arena<Expr>,
+    value: codira_comptime::Value,
+) -> Option<Expr> {
+    match value {
+        codira_comptime::Value::Bool(b) => Some(Expr::Literal(Literal::Bool(b))),
+        codira_comptime::Value::Int(v) if v >= 0 => {
+            Some(Expr::Literal(Literal::Int(LiteralInt {
+                kind: LiteralIntKind::Unsuffixed,
+                value: v as u128,
+            })))
+        }
+        codira_comptime::Value::Int(v) => {
+            let inner = exprs.alloc(Expr::Literal(Literal::Int(LiteralInt {
+                kind: LiteralIntKind::Unsuffixed,
+                value: v.unsigned_abs() as u128,
+            })));
+            Some(Expr::UnaryOp {
+                expr: inner,
+                op: UnaryOp::Neg,
+            })
+        }
+        codira_comptime::Value::Unit => None,
+    }
+}
+
+fn build_op(
+    exprs: &Arena<Expr>,
+    id: ExprId,
+    body: &mut codira_mir::Body,
+) -> Option<codira_mir::OpId> {
+    use codira_mir::{Attr, OpKind, Region};
+
+    match &exprs[id] {
+        Expr::Literal(Literal::Bool(b)) => Some(body.push(OpKind::Const(Attr::Bool(*b)), [])),
+        Expr::Literal(Literal::Int(LiteralInt { value, .. })) => {
+            let v = i64::try_from(*value).ok()?;
+            Some(body.push(OpKind::Const(Attr::Int(v)), []))
+        }
+        Expr::UnaryOp { expr, op } => {
+            let inner = build_op(exprs, *expr, body)?;
+            let kind = match op {
+                UnaryOp::Neg => OpKind::Neg,
+                UnaryOp::Not => OpKind::Not,
+            };
+            Some(body.push(kind, [inner]))
+        }
+        Expr::BinaryOp {
+            lhs,
+            rhs,
+            op: Some(op),
+        } => {
+            let lhs_id = build_op(exprs, *lhs, body)?;
+            let rhs_id = build_op(exprs, *rhs, body)?;
+            let kind = binary_op_kind(*op)?;
+            Some(body.push(kind, [lhs_id, rhs_id]))
+        }
+        Expr::If {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            let cond_id = build_op(exprs, *condition, body)?;
+
+            let mut then_body = codira_mir::Body::new();
+            build_op(exprs, *then_branch, &mut then_body)?;
+
+            let mut else_body = codira_mir::Body::new();
+            if let Some(else_branch) = else_branch {
+                build_op(exprs, *else_branch, &mut else_body)?;
+            }
+
+            Some(body.push_with_regions(
+                OpKind::If,
+                [cond_id],
+                [Region::new(then_body), Region::new(else_body)],
+            ))
+        }
+        Expr::Block { statements, tail } if statements.is_empty() => build_op(exprs, (*tail)?, body),
+        // `Path`, `Call`, `MethodCall`, `Index`, `Array`, `RecordLit`,
+        // `Field`, `Loop`, `While`, `Return`, `Break`, blocks with
+        // statements, `Missing`, and string/float literals are all out of
+        // scope for this session's restricted interpreter -- see module
+        // doc and spec/KGEN_SUPERSET_STATUS.md.
+        _ => None,
+    }
+}
+
+fn binary_op_kind(op: BinaryOp) -> Option<codira_mir::OpKind> {
+    use codira_mir::OpKind;
+    Some(match op {
+        BinaryOp::ArithOp(ArithOp::Add) => OpKind::Add,
+        BinaryOp::ArithOp(ArithOp::Subtract) => OpKind::Sub,
+        BinaryOp::ArithOp(ArithOp::Multiply) => OpKind::Mul,
+        BinaryOp::ArithOp(ArithOp::Divide) => OpKind::Div,
+        BinaryOp::ArithOp(ArithOp::Remainder) => OpKind::Rem,
+        // Bitwise/shift ops have no codira_mir core.* op yet -- only the
+        // arithmetic/comparison/logical subset needed for `comptime { 2 + 2
+        // }`-shaped code exists so far. See architecture doc §2.1.
+        BinaryOp::ArithOp(
+            ArithOp::LeftShift | ArithOp::RightShift | ArithOp::BitAnd | ArithOp::BitOr
+            | ArithOp::BitXor,
+        ) => return None,
+        BinaryOp::LogicOp(LogicOp::And) => OpKind::And,
+        BinaryOp::LogicOp(LogicOp::Or) => OpKind::Or,
+        BinaryOp::CmpOp(CmpOp::Eq { negated: false }) => OpKind::Eq,
+        BinaryOp::CmpOp(CmpOp::Eq { negated: true }) => OpKind::Ne,
+        BinaryOp::CmpOp(CmpOp::Ord {
+            ordering: Ordering::Less,
+            strict: true,
+        }) => OpKind::Lt,
+        BinaryOp::CmpOp(CmpOp::Ord {
+            ordering: Ordering::Less,
+            strict: false,
+        }) => OpKind::Le,
+        BinaryOp::CmpOp(CmpOp::Ord {
+            ordering: Ordering::Greater,
+            strict: true,
+        }) => OpKind::Gt,
+        BinaryOp::CmpOp(CmpOp::Ord {
+            ordering: Ordering::Greater,
+            strict: false,
+        }) => OpKind::Ge,
+        BinaryOp::Assignment { .. } => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use la_arena::Arena;
+
+    use super::*;
+    use crate::expr::{Literal, LiteralInt, LiteralIntKind};
+
+    #[test]
+    fn folds_two_plus_two() {
+        let mut exprs = Arena::new();
+        let two_a = exprs.alloc(Expr::Literal(Literal::Int(LiteralInt {
+            kind: LiteralIntKind::Unsuffixed,
+            value: 2,
+        })));
+        let two_b = exprs.alloc(Expr::Literal(Literal::Int(LiteralInt {
+            kind: LiteralIntKind::Unsuffixed,
+            value: 2,
+        })));
+        let sum = exprs.alloc(Expr::BinaryOp {
+            lhs: two_a,
+            rhs: two_b,
+            op: Some(BinaryOp::ArithOp(ArithOp::Add)),
+        });
+        let block = exprs.alloc(Expr::Block {
+            statements: Vec::new(),
+            tail: Some(sum),
+        });
+
+        let value = try_eval(&exprs, block).unwrap();
+        assert_eq!(value, codira_comptime::Value::Int(4));
+
+        let folded = value_to_expr(&mut exprs, value).unwrap();
+        assert_eq!(
+            folded,
+            Expr::Literal(Literal::Int(LiteralInt {
+                kind: LiteralIntKind::Unsuffixed,
+                value: 4,
+            }))
+        );
+    }
+
+    #[test]
+    fn negative_result_wraps_in_unary_neg() {
+        let mut exprs = Arena::new();
+        let zero = exprs.alloc(Expr::Literal(Literal::Int(LiteralInt {
+            kind: LiteralIntKind::Unsuffixed,
+            value: 0,
+        })));
+        let five = exprs.alloc(Expr::Literal(Literal::Int(LiteralInt {
+            kind: LiteralIntKind::Unsuffixed,
+            value: 5,
+        })));
+        let diff = exprs.alloc(Expr::BinaryOp {
+            lhs: zero,
+            rhs: five,
+            op: Some(BinaryOp::ArithOp(ArithOp::Subtract)),
+        });
+
+        let value = try_eval(&exprs, diff).unwrap();
+        assert_eq!(value, codira_comptime::Value::Int(-5));
+
+        let folded = value_to_expr(&mut exprs, value).unwrap();
+        match folded {
+            Expr::UnaryOp { expr, op: UnaryOp::Neg } => {
+                assert_eq!(
+                    exprs[expr],
+                    Expr::Literal(Literal::Int(LiteralInt {
+                        kind: LiteralIntKind::Unsuffixed,
+                        value: 5,
+                    }))
+                );
+            }
+            other => panic!("expected UnaryOp::Neg, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bails_out_on_unsupported_construct() {
+        // `Missing` stands in for anything this restricted interpreter
+        // doesn't handle (name references, calls, etc. -- see module doc);
+        // the important property under test is that an unsupported node
+        // anywhere in the tree causes a clean `None`, not a panic or a
+        // wrong answer.
+        let mut exprs = Arena::new();
+        let unsupported = exprs.alloc(Expr::Missing);
+        assert!(try_eval(&exprs, unsupported).is_none());
+    }
+}

--- a/crates/codira_hir/src/expr.rs
+++ b/crates/codira_hir/src/expr.rs
@@ -934,11 +934,27 @@ impl<'a> ExprCollector<'a> {
                 let index = self.collect_expr_opt(e.index());
                 self.alloc_expr(Expr::Index { base, index }, syntax_ptr)
             }
-            // `comptime { .. }` is transparently lowered to its inner block: the
-            // block's contents are fully type-checked like any other block, but the
-            // "must fully evaluate at compile time" restriction described in the
-            // language spec is not yet enforced here.
-            ast::ExprKind::ComptimeExpr(e) => self.collect_block_opt(e.body()),
+            // `comptime { .. }` lowers its inner block exactly as before (so
+            // anything inside still fully type-checks like an ordinary
+            // block), then attempts to fold it to a concrete literal via
+            // `codira_comptime` for the restricted subset described in
+            // `comptime_fold`'s module doc (literals, arithmetic/
+            // comparison/logical ops, unary neg/not, if/else, no
+            // statements/name references/calls). Blocks outside that
+            // subset fall back to the block itself, unevaluated -- the
+            // "must fully evaluate at compile time" restriction described
+            // in the language spec is not yet enforced for those.
+            ast::ExprKind::ComptimeExpr(e) => {
+                let block = self.collect_block_opt(e.body());
+                match crate::comptime_fold::try_eval(&self.exprs, block) {
+                    Some(value) => match crate::comptime_fold::value_to_expr(&mut self.exprs, value)
+                    {
+                        Some(folded) => self.alloc_expr(folded, syntax_ptr),
+                        None => block,
+                    },
+                    None => block,
+                }
+            }
             // `match`, `perform`, `handle`, and postfix `!` (force-unwrap) are fully
             // parsed (see `codira_syntax`), but HIR-level lowering -- pattern
             // exhaustiveness checking, effect obligation checking, and optional

--- a/crates/codira_hir/src/item_tree.rs
+++ b/crates/codira_hir/src/item_tree.rs
@@ -310,10 +310,30 @@ pub struct Function {
     pub name: Name,
     pub visibility: RawVisibilityId,
     pub types: TypeRefMap,
+    pub generic_params: Box<[GenericParamData]>,
     pub params: IdRange<Param>,
     pub ret_type: LocalTypeRefId,
     pub ast_id: FileAstId<ast::FunctionDef>,
     pub(crate) flags: FunctionFlags,
+}
+
+/// A single entry of a `[T, N: usize]`-style generic parameter list, as
+/// captured by the item tree.
+///
+/// `bound` is resolved against the *same* [`TypeRefMap`] as the rest of the
+/// owning item (`Function::types` / `Struct::types`) — it is not its own
+/// map. This mirrors how `Param::type_ref` and `Field::type_ref` work.
+///
+/// The grammar does not distinguish a trait-bounded type parameter
+/// (`T: Comparable`) from a value/const parameter (`N: usize`) — both parse
+/// as `name (":" type)?`. Telling them apart is a name-resolution concern
+/// (does `bound` resolve to a trait or to a concrete non-trait type?), left
+/// to the consumer of this data (see `codira_comptime`'s specialization
+/// logic), not something the item tree itself decides.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct GenericParamData {
+    pub name: Name,
+    pub bound: Option<LocalTypeRefId>,
 }
 
 bitflags::bitflags! {
@@ -360,6 +380,7 @@ pub struct Struct {
     pub name: Name,
     pub visibility: RawVisibilityId,
     pub types: TypeRefMap,
+    pub generic_params: Box<[GenericParamData]>,
     pub fields: Fields,
     pub ast_id: FileAstId<ast::StructDef>,
 }

--- a/crates/codira_hir/src/item_tree/lower.rs
+++ b/crates/codira_hir/src/item_tree/lower.rs
@@ -12,14 +12,15 @@ use std::{collections::HashMap, convert::TryInto, marker::PhantomData, sync::Arc
 use la_arena::{Idx, RawIdx};
 use codira_hir_input::FileId;
 use codira_syntax::ast::{
-    self, ExternOwner, ModuleItemOwner, NameOwner, StructKind, TypeAscriptionOwner,
+    self, ExternOwner, GenericParamsOwner, ModuleItemOwner, NameOwner, StructKind,
+    TypeAscriptionOwner,
 };
 use smallvec::SmallVec;
 
 use super::{
-    diagnostics, AssociatedItem, Field, Fields, Function, FunctionFlags, IdRange, Impl, ItemTree,
-    ItemTreeData, ItemTreeNode, ItemVisibilities, LocalItemTreeId, ModItem, Param, ParamAstId,
-    RawVisibilityId, Struct, TypeAlias,
+    diagnostics, AssociatedItem, Field, Fields, Function, FunctionFlags, GenericParamData,
+    IdRange, Impl, ItemTree, ItemTreeData, ItemTreeNode, ItemVisibilities, LocalItemTreeId,
+    ModItem, Param, ParamAstId, RawVisibilityId, Struct, TypeAlias,
 };
 use crate::{
     item_tree::Import,
@@ -170,10 +171,33 @@ impl Context {
     }
 
     /// Lowers a function
+    /// Lowers a `[T, U: Bound]`-style generic parameter list, if present.
+    ///
+    /// Bounds are allocated into `types` so callers can resolve them the
+    /// same way they resolve param/field/return types (see
+    /// [`GenericParamData`]).
+    fn lower_generic_params(
+        &mut self,
+        owner: &impl GenericParamsOwner,
+        types: &mut TypeRefMapBuilder,
+    ) -> Box<[GenericParamData]> {
+        let Some(list) = owner.generic_param_list() else {
+            return Box::new([]);
+        };
+        list.generic_params()
+            .filter_map(|param| {
+                let name = param.name()?.as_name();
+                let bound = param.bound().map(|bound| types.alloc_from_node(&bound));
+                Some(GenericParamData { name, bound })
+            })
+            .collect()
+    }
+
     fn lower_function(&mut self, func: &ast::FunctionDef) -> Option<LocalItemTreeId<Function>> {
         let name = func.name()?.as_name();
         let visibility = lower_visibility(func);
         let mut types = TypeRefMap::builder();
+        let generic_params = self.lower_generic_params(func, &mut types);
 
         // Lower all the params
         let start_param_idx = self.next_param_idx();
@@ -228,6 +252,7 @@ impl Context {
             name,
             visibility,
             types,
+            generic_params,
             params,
             ret_type,
             ast_id,
@@ -242,6 +267,7 @@ impl Context {
         let name = strukt.name()?.as_name();
         let visibility = lower_visibility(strukt);
         let mut types = TypeRefMap::builder();
+        let generic_params = self.lower_generic_params(strukt, &mut types);
         let fields = self.lower_fields(&strukt.kind(), &mut types);
         let ast_id = self.source_ast_id_map.ast_id(strukt);
 
@@ -250,6 +276,7 @@ impl Context {
             name,
             visibility,
             types,
+            generic_params,
             fields,
             ast_id,
         };

--- a/crates/codira_hir/src/item_tree/pretty.rs
+++ b/crates/codira_hir/src/item_tree/pretty.rs
@@ -9,8 +9,8 @@ use std::{fmt, fmt::Write};
 
 use crate::{
     item_tree::{
-        Fields, Function, Impl, Import, ItemTree, LocalItemTreeId, ModItem, Param, RawVisibilityId,
-        Struct, TypeAlias,
+        Fields, Function, GenericParamData, Impl, Import, ItemTree, LocalItemTreeId, ModItem,
+        Param, RawVisibilityId, Struct, TypeAlias,
     },
     path::ImportAlias,
     pretty::{print_path, print_type_ref},
@@ -128,11 +128,13 @@ impl Printer<'_> {
             visibility,
             name,
             types,
+            generic_params,
             fields,
             ast_id: _,
         } = &self.tree[it];
         self.print_visibility(*visibility)?;
         write!(self, "struct {name}")?;
+        self.print_generic_params(generic_params, types)?;
         match fields {
             Fields::Record(fields) => {
                 self.whitespace()?;
@@ -175,6 +177,7 @@ impl Printer<'_> {
             name,
             visibility,
             types,
+            generic_params,
             params,
             ret_type,
             ast_id: _,
@@ -185,6 +188,7 @@ impl Printer<'_> {
             write!(self, "extern ")?;
         }
         write!(self, "fn {name}")?;
+        self.print_generic_params(generic_params, types)?;
         write!(self, "(")?;
         if !params.is_empty() {
             self.indented(|this| {
@@ -210,6 +214,29 @@ impl Printer<'_> {
         write!(self, ") -> ")?;
         self.print_type_ref(*ret_type, types)?;
         writeln!(self, ";")
+    }
+
+    /// Prints a `[T, N: usize]`-style generic parameter list, if non-empty.
+    fn print_generic_params(
+        &mut self,
+        generic_params: &[GenericParamData],
+        types: &TypeRefMap,
+    ) -> fmt::Result {
+        if generic_params.is_empty() {
+            return Ok(());
+        }
+        write!(self, "[")?;
+        for (i, param) in generic_params.iter().enumerate() {
+            if i > 0 {
+                write!(self, ", ")?;
+            }
+            write!(self, "{}", param.name)?;
+            if let Some(bound) = param.bound {
+                write!(self, ": ")?;
+                self.print_type_ref(bound, types)?;
+            }
+        }
+        write!(self, "]")
     }
 
     /// Prints a [`RawVisibilityId`] to the buffer.

--- a/crates/codira_hir/src/item_tree/tests.rs
+++ b/crates/codira_hir/src/item_tree/tests.rs
@@ -89,6 +89,22 @@ fn test_impls() {
 }
 
 #[test]
+fn test_generic_params() {
+    insta::assert_snapshot!(print_item_tree(
+        r#"
+    struct Box[T] {
+        value: T,
+    }
+    struct SIMD[T, N: usize] {
+        data: T,
+    }
+    func first[T](items: T) -> T {}
+    "#
+    )
+    .unwrap());
+}
+
+#[test]
 fn test_duplicate_import() {
     insta::assert_snapshot!(print_item_tree(
         r#"

--- a/crates/codira_hir/src/lib.rs
+++ b/crates/codira_hir/src/lib.rs
@@ -49,6 +49,7 @@ use crate::{name::AsName, source_id::AstIdMap};
 #[macro_use]
 mod macros;
 mod code_model;
+mod comptime_fold;
 mod db;
 pub mod diagnostics;
 mod display;

--- a/crates/codira_lld/Cargo.toml
+++ b/crates/codira_lld/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["linkers", "compilers"]
 
 [dependencies]
 libc = "0.2.138"
-llvm-sys = "220.0.0"
+llvm-sys = "221.0.0"
 
 [build-dependencies]
 cc = "1.0.116"

--- a/crates/codira_mir/Cargo.toml
+++ b/crates/codira_mir/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "codira_mir"
+description = "Parametric mid-level IR (generators, structured control flow, SIMD/param ops) sitting between codira_hir and codira_codegen -- see spec/KGEN_SUPERSET_ARCHITECTURE.md"
+keywords = ["game", "hot-reloading", "language", "codira", "compiler"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+la-arena = { workspace = true }
+smallvec = { workspace = true }
+smol_str = { workspace = true }

--- a/crates/codira_mir/src/generator.rs
+++ b/crates/codira_mir/src/generator.rs
@@ -1,0 +1,89 @@
+//! Generators: parametric function/struct templates.
+//!
+//! Structural analog of `kgen.generator` / `kgen.struct.generator`
+//! (`modular/KGEN/docs/MojoCompilerWalkthrough.md` §"Generators: Function
+//! and Struct") -- see `spec/KGEN_SUPERSET_ARCHITECTURE.md` §3. Elaboration
+//! (in the separate `codira_comptime` crate) consumes a [`Generator`] plus
+//! concrete parameter values and produces a monomorphized [`Body`].
+
+use la_arena::{Arena, Idx};
+use smol_str::SmolStr;
+
+use crate::op::Body;
+
+/// One named parameter of a generator (`T` or `N` in `SIMD[T, N: usize]`).
+///
+/// Whether this is a *type* parameter (its use sites expect a type) or a
+/// *value* parameter (its use sites expect a concrete constant, like a
+/// const-generic array length) is not decided here -- the grammar doesn't
+/// distinguish the two either (see `codira_hir::item_tree::GenericParamData`'s
+/// doc comment, added alongside this crate). It's a property of how the
+/// parameter is *used* in the body, resolved during elaboration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GeneratorParam {
+    pub name: SmolStr,
+}
+
+/// A parametric function template (KGEN analog: `kgen.generator`).
+///
+/// After elaboration with concrete parameter values, this becomes a
+/// concrete [`Body`] (KGEN analog: `kgen.func`) -- elaboration doesn't
+/// change the `Body` type, it just means every `param.ref` op in the body
+/// has been folded away by the interpreter (see `codira_comptime`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Generator {
+    pub name: SmolStr,
+    pub params: Vec<GeneratorParam>,
+    pub body: Body,
+}
+
+/// A parametric struct template (KGEN analog: `kgen.struct.generator`).
+///
+/// Field *types* are deliberately not modeled yet (only field names) --
+/// doing so honestly requires a type-expression IR shared with
+/// `codira_hir::type_ref`, which is out of scope for this session (see
+/// `spec/KGEN_SUPERSET_ARCHITECTURE.md` §8, non-goals). This exists now so
+/// `GeneratorId`/`GeneratorStore` have a real second case to be generic
+/// over, matching KGEN's `GeneratorOpInterface` covering both function and
+/// struct generators uniformly.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StructGenerator {
+    pub name: SmolStr,
+    pub params: Vec<GeneratorParam>,
+    pub field_names: Vec<SmolStr>,
+}
+
+pub type GeneratorId = Idx<Generator>;
+pub type StructGeneratorId = Idx<StructGenerator>;
+
+/// Owns every [`Generator`]/[`StructGenerator`] produced while lowering a
+/// compilation unit. One store is shared by every generator reference
+/// (`param.ref`-style lookups go through here), the same role KGEN's
+/// module-level symbol table plays for `kgen.generator` symbols.
+#[derive(Debug, Default)]
+pub struct GeneratorStore {
+    generators: Arena<Generator>,
+    struct_generators: Arena<StructGenerator>,
+}
+
+impl GeneratorStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_generator(&mut self, generator: Generator) -> GeneratorId {
+        self.generators.alloc(generator)
+    }
+
+    pub fn add_struct_generator(&mut self, generator: StructGenerator) -> StructGeneratorId {
+        self.struct_generators.alloc(generator)
+    }
+
+    pub fn generator(&self, id: GeneratorId) -> &Generator {
+        &self.generators[id]
+    }
+
+    pub fn struct_generator(&self, id: StructGeneratorId) -> &StructGenerator {
+        &self.struct_generators[id]
+    }
+}

--- a/crates/codira_mir/src/lib.rs
+++ b/crates/codira_mir/src/lib.rs
@@ -1,0 +1,25 @@
+//! Copyright (c) 2026 Omnira CJSC
+//!
+//! `codira_mir` -- Codira's parametric mid-level IR.
+//!
+//! Sits between `codira_hir` and `codira_codegen`, modeled on (and
+//! extending) the pipeline shape of Modular's KGEN (the Mojo compiler).
+//! See `spec/KGEN_SUPERSET_ARCHITECTURE.md` for the full design rationale
+//! and `spec/KGEN_SUPERSET_STATUS.md` for exactly what is implemented vs.
+//! designed as of a given session.
+//!
+//! This crate defines only the IR data model (this module) and generator
+//! declarations (`generator`). Compile-time evaluation/elaboration lives in
+//! the separate `codira_comptime` crate, which depends on this one -- kept
+//! separate so the IR data model has no evaluation-strategy dependencies.
+
+mod generator;
+mod op;
+
+pub use generator::{
+    Generator, GeneratorId, GeneratorParam, GeneratorStore, StructGenerator, StructGeneratorId,
+};
+pub use op::{Attr, Body, Op, OpId, OpKind, Region};
+
+#[cfg(test)]
+mod tests;

--- a/crates/codira_mir/src/op.rs
+++ b/crates/codira_mir/src/op.rs
@@ -1,0 +1,157 @@
+//! The core IR data model: [`Op`], [`OpKind`], [`Attr`], [`Body`], [`Region`].
+//!
+//! This mirrors MLIR's generic `Operation`/`Region`/`Attribute` model (and,
+//! more specifically, the shape of KGEN's `kgen`/`pop`/`hlcf` dialects --
+//! see `spec/KGEN_SUPERSET_ARCHITECTURE.md` §2) without a TableGen/C++
+//! dialect-registration mechanism: op kinds are grouped into "dialects" by
+//! naming convention on the [`OpKind`] variants (`core.*`, `param.*`,
+//! `simd.*`, `cf.*`) rather than by separate Rust crates or types, per
+//! §7.2's "one IR, not four dialects" simplification.
+
+use la_arena::{Arena, Idx};
+use smallvec::SmallVec;
+use smol_str::SmolStr;
+
+/// A compile-time-known value attached to an [`Op`].
+///
+/// KGEN's terminology (`DesignOverview.md`, "Generator Parameter
+/// Arguments"): attributes are *not* SSA values -- they are the meta-program
+/// data a generator acts on at elaboration time, as opposed to [`OpId`]
+/// operands, which are ordinary SSA values computed at (kernel) runtime.
+/// Both distinctions are preserved here.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Attr {
+    Int(i64),
+    Bool(bool),
+    Unit,
+    /// An unresolved reference to a generator parameter (e.g. `N` in
+    /// `SIMD[T, N: usize]`) -- only becomes a concrete `Int`/`Bool`/etc.
+    /// during elaboration (`codira_comptime`). See architecture doc §3.
+    ParamRef(SmolStr),
+}
+
+/// One IR operation. Grouped into "dialects" by variant name prefix in the
+/// doc comment below, matching the table in the architecture doc §2.1.
+#[derive(Debug, Clone, PartialEq)]
+pub enum OpKind {
+    // ---- core.* (KGEN analog: concrete `kgen.*` ops) ----------------------
+    /// `core.const` -- materializes a literal [`Attr`] as a value.
+    Const(Attr),
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Rem,
+    Neg,
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    And,
+    Or,
+    Not,
+
+    // ---- param.* (KGEN analog: `kgen.param.*`) -----------------------------
+    /// `param.ref` -- reference to a not-yet-resolved generator parameter.
+    ParamRef(SmolStr),
+
+    // ---- cf.* (KGEN analog: `hlcf.*`) --------------------------------------
+    /// `cf.if` -- one operand (the condition), two regions (`then`, `else`).
+    /// Both regions must be present; a missing `else` is represented as an
+    /// empty region yielding `Attr::Unit`.
+    If,
+    /// `cf.for` -- structured for-loop. Declared for IR completeness (see
+    /// architecture doc §2.1) but **not yet interpreted** by
+    /// `codira_comptime` this session -- see spec/KGEN_SUPERSET_STATUS.md.
+    For,
+    /// `cf.while` -- structured while-loop. Same status as `For`.
+    While,
+    // ---- simd.* (KGEN analog: `pop.*`) -------------------------------------
+    // Deliberately not modeled yet: no SIMD op variants exist until a real
+    // consumer (the std/builtin/simd.code lowering) is wired up. Adding
+    // speculative variants with no interpreter/codegen support would just be
+    // unverified surface area -- see architecture doc §8 non-goals.
+}
+
+/// One operation: a kind, its SSA operands (other ops in the same [`Body`]),
+/// and any nested [`Region`]s (e.g. `cf.if`'s `then`/`else` bodies).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Op {
+    pub kind: OpKind,
+    pub operands: SmallVec<[OpId; 2]>,
+    pub regions: SmallVec<[Region; 0]>,
+}
+
+pub type OpId = Idx<Op>;
+
+/// A straight-line sequence of [`Op`]s. Its "result" (matching MLIR's
+/// single-block-region-yields-last-value convention, used here instead of a
+/// full multi-block CFG since nothing in this IR yet needs back-edges within
+/// a single region -- `cf.for`/`cf.while` bodies are themselves `Body`s, not
+/// arbitrary block graphs) is the value of its last op, if any.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Body {
+    ops: Arena<Op>,
+}
+
+impl Body {
+    pub fn new() -> Self {
+        Self { ops: Arena::new() }
+    }
+
+    pub fn push(&mut self, kind: OpKind, operands: impl IntoIterator<Item = OpId>) -> OpId {
+        self.ops.alloc(Op {
+            kind,
+            operands: operands.into_iter().collect(),
+            regions: SmallVec::new(),
+        })
+    }
+
+    pub fn push_with_regions(
+        &mut self,
+        kind: OpKind,
+        operands: impl IntoIterator<Item = OpId>,
+        regions: impl IntoIterator<Item = Region>,
+    ) -> OpId {
+        self.ops.alloc(Op {
+            kind,
+            operands: operands.into_iter().collect(),
+            regions: regions.into_iter().collect(),
+        })
+    }
+
+    pub fn get(&self, id: OpId) -> &Op {
+        &self.ops[id]
+    }
+
+    /// The op whose value this body evaluates to: its last op, if any.
+    pub fn result(&self) -> Option<OpId> {
+        self.ops.iter().last().map(|(id, _)| id)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ops.iter().next().is_none()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (OpId, &Op)> {
+        self.ops.iter()
+    }
+}
+
+/// A nested region: just a [`Body`] today. Kept as a distinct type (rather
+/// than using `Body` directly as the field type on [`Op`]) so the
+/// architecture doc's "Region" terminology has a stable, addressable Rust
+/// name to grow block-arguments/multi-block support into later without
+/// another rename.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Region {
+    pub body: Body,
+}
+
+impl Region {
+    pub fn new(body: Body) -> Self {
+        Self { body }
+    }
+}

--- a/crates/codira_mir/src/tests.rs
+++ b/crates/codira_mir/src/tests.rs
@@ -1,0 +1,61 @@
+use crate::{Attr, Body, Generator, GeneratorParam, GeneratorStore, OpKind, Region};
+
+#[test]
+fn builds_straight_line_arithmetic() {
+    // `2 + 2`
+    let mut body = Body::new();
+    let two_a = body.push(OpKind::Const(Attr::Int(2)), []);
+    let two_b = body.push(OpKind::Const(Attr::Int(2)), []);
+    let sum = body.push(OpKind::Add, [two_a, two_b]);
+
+    assert_eq!(body.result(), Some(sum));
+    assert_eq!(body.get(sum).operands.as_slice(), &[two_a, two_b]);
+}
+
+#[test]
+fn builds_if_with_nested_regions() {
+    // `if true { 1 } else { 0 }`
+    let mut body = Body::new();
+    let cond = body.push(OpKind::Const(Attr::Bool(true)), []);
+
+    let mut then_body = Body::new();
+    then_body.push(OpKind::Const(Attr::Int(1)), []);
+    let mut else_body = Body::new();
+    else_body.push(OpKind::Const(Attr::Int(0)), []);
+
+    let if_op = body.push_with_regions(
+        OpKind::If,
+        [cond],
+        [Region::new(then_body), Region::new(else_body)],
+    );
+
+    let op = body.get(if_op);
+    assert_eq!(op.regions.len(), 2);
+    assert!(op.regions[0].body.result().is_some());
+    assert!(op.regions[1].body.result().is_some());
+}
+
+#[test]
+fn generator_store_round_trips() {
+    let mut store = GeneratorStore::new();
+    let mut body = Body::new();
+    body.push(OpKind::ParamRef("N".into()), []);
+
+    let id = store.add_generator(Generator {
+        name: "identity".into(),
+        params: vec![GeneratorParam { name: "N".into() }],
+        body,
+    });
+
+    let generator = store.generator(id);
+    assert_eq!(generator.name, "identity");
+    assert_eq!(generator.params.len(), 1);
+    assert_eq!(generator.params[0].name, "N");
+}
+
+#[test]
+fn empty_body_has_no_result() {
+    let body = Body::new();
+    assert!(body.is_empty());
+    assert_eq!(body.result(), None);
+}

--- a/crates/codira_syntax/examples/check_file.rs
+++ b/crates/codira_syntax/examples/check_file.rs
@@ -1,0 +1,33 @@
+// Parse-only checker for `.code` files: `cargo run -p codira_syntax --example
+// check_file -- path/to/file.code [more files...]`. Prints OK/FAIL per file
+// and every SyntaxError with its byte offset; exits 1 if any file failed.
+//
+// Written to verify std/**/*.code syntax migrations against the current
+// grammar (see spec/KGEN_SUPERSET_STATUS.md) without needing the LLVM
+// toolchain codira_codegen/codira_compiler require -- codira_syntax has no
+// such dependency, so this works in any environment that can build Rust.
+// Kept as a standing dev tool for the rest of the std/ migration, not a
+// one-off script.
+use std::{env, fs};
+
+use codira_syntax::SourceFile;
+
+fn main() {
+    let mut any_errors = false;
+    for path in env::args().skip(1) {
+        let text = fs::read_to_string(&path).expect("read file");
+        let parse = SourceFile::parse(&text);
+        if parse.errors().is_empty() {
+            println!("OK   {path}");
+        } else {
+            any_errors = true;
+            println!("FAIL {path}");
+            for err in parse.errors() {
+                println!("     {err:?}");
+            }
+        }
+    }
+    if any_errors {
+        std::process::exit(1);
+    }
+}

--- a/std/builtin/traits.code
+++ b/std/builtin/traits.code
@@ -13,6 +13,19 @@
 //   - Identity:    Identifiable
 //   - Containers:  Indexable, Iterable, Collection, Lengthable
 // =============================================================================
+//
+// Migration note (2026-08-20): verified to parse cleanly under the current
+// grammar (spec/LANGUAGE_SPEC.md; checked via codira_syntax::SourceFile::
+// parse -- zero SyntaxErrors). The only fix needed was dropping the `&`
+// reference sigil from `Hasher`/`Writer`/`Formatter` parameter types --
+// Codira's grammar has no `&`/`&mut` at all (see
+// agents/RUST_TO_CODIRA_MIGRATION.md §3); those types are meant to be
+// `class` (GC reference) types, which need no sigil to pass by reference.
+// `trait` itself is still a Tier-2 construct (parses, not yet resolved into
+// name-resolvable HIR items -- see spec's §12 implementation status), so
+// this is "parses correctly," not "compiles and runs" -- see
+// spec/KGEN_SUPERSET_STATUS.md for the session-wide status.
+// =============================================================================
 
 // ---------------------------------------------------------------------------
 // Lifecycle traits
@@ -108,12 +121,12 @@ public trait Comparable: EqualityComparable {
 // A type that can produce a deterministic hash value.
 public trait Hashable {
     // Compute a hash of `self` and fold it into the given hasher state.
-    func hash(self, hasher: &Hasher) -> void;
+    func hash(self, hasher: Hasher) -> void;
 
     // Convenience: return a standalone u64 hash.
     func hash_value(self) -> u64 {
         let h = Hasher.new();
-        self.hash(&h);
+        self.hash(h);
         return h.finish();
     }
 }
@@ -139,13 +152,13 @@ public trait Representable {
 // A type that can write its textual form into an output stream.
 public trait Writable {
     // Write `self` into `writer`.
-    func write_to(self, writer: &Writer) -> void;
+    func write_to(self, writer: Writer) -> void;
 }
 
 // A type that supports format-string interpolation with a format spec.
 public trait Formattable {
     // Format `self` according to `spec` and write into `formatter`.
-    func format(self, spec: StringSlice, formatter: &Formatter) -> void;
+    func format(self, spec: StringSlice, formatter: Formatter) -> void;
 }
 
 // ---------------------------------------------------------------------------

--- a/std/collections/optional.code
+++ b/std/collections/optional.code
@@ -1,181 +1,154 @@
-// std/collections/optional.code
-// Optional[T] — a type-safe nullable container.
-// Represents either a present value (Some) or absence (None).
-// Eliminates null pointer errors by making absence explicit in the type system.
+// =============================================================================
+// std/collections/optional.code — Optional[T]: a type-safe nullable container
+// =============================================================================
+//
+// Represents either a present value (Some) or absence (None). Eliminates
+// null-pointer errors by making absence explicit in the type system.
+//
+// Migration note (2026-08-20): rewritten from the pre-redesign syntax
+// (`struct(value) Optional[T]`) to the current grammar
+// (spec/LANGUAGE_SPEC.md) -- verified to parse cleanly via
+// codira_syntax::SourceFile::parse (zero SyntaxErrors). Three things
+// changed versus a naive re-spelling of the original file, each found by
+// actually running the parser rather than assumed:
+//
+// 1. Every higher-order method (`map`, `and_then`, `or_else`, `filter_opt`,
+//    `map_or`, `map_or_else`, `unwrap_or_else`) took a `func(T) -> U`-typed
+//    parameter. Codira has no first-class function-value/closure type at
+//    all (agents/RUST_TO_CODIRA_MIGRATION.md §7: "No evidence of closures,
+//    Fn/FnMut/FnOnce... was found anywhere in the grammar"), so there is no
+//    honest current-syntax spelling for these -- they are omitted rather
+//    than translated to something that only looks like it works.
+// 2. All functions take `opt` (not `self`) as an ordinary first parameter.
+//    `self: Type` with an explicit type ascription is NOT valid outside a
+//    method-receiver position -- the grammar's self-param production has no
+//    `: Type` form for a plain top-level function (confirmed empirically:
+//    `func f(self: T) -> T` fails to parse with "expected value parameter"
+//    even though `func f(x: T) -> T` parses fine). This corrects a mistake
+//    in this file's first migration pass this session.
+// 3. Struct-literal construction of a generic type must omit the explicit
+//    `[T]` argument list -- `Optional[T] { value: v, has_value: true }`
+//    does not parse ("expected expression" right after `Optional[T]`), but
+//    `Optional { value: v, has_value: true }` (relying on inference) does.
+//    Explicit generic type arguments are only legal in type position, not
+//    at a construction call site (consistent with USING_CODIRA.md §8's "no
+//    turbofish" rule, just not spelled out for record literals specifically
+//    until this was checked directly).
+//
+// `struct Optional[T]` is `struct` by default (value type) in the current
+// grammar -- the old `struct(value)`/`struct(gc)` memory-kind annotation no
+// longer exists (agents/RUST_TO_CODIRA_MIGRATION.md §1). Generics (`[T]`)
+// are parser-verified only, not yet codegen-verified end to end -- see
+// spec/KGEN_SUPERSET_ARCHITECTURE.md for the work in progress to close that
+// gap, and spec/KGEN_SUPERSET_STATUS.md for this session's overall status.
+// Associated/instance-call syntax (`opt.unwrap()`) is not confirmed to
+// resolve for free functions outside `extend` either, so callers should use
+// ordinary call syntax, e.g. `unwrap(my_optional)`.
+// =============================================================================
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Optional[T] — can hold zero or one value of type T.
-// ─────────────────────────────────────────────────────────────────────────────
-
-struct(value) Optional[T] {
-    value:    T,
+public struct Optional[T] {
+    value: T,
     has_value: bool,
 }
 
 // ── Construction ─────────────────────────────────────────────────────────────
 
-/// Creates an Optional containing `value`.
+// Creates an Optional containing `value`.
 public func some[T](value: T) -> Optional[T] {
-    return Optional[T] { value: value, has_value: true };
+    Optional { value: value, has_value: true }
 }
 
-/// Creates an empty Optional (no value present).
-public func none[T]() -> Optional[T] {
-    return Optional[T] { value: zero_value[T](), has_value: false };
+// Creates an empty Optional (no value present). `default` stands in for
+// Mojo's zero-initialization of the unused payload slot -- Codira has no
+// `zero_value[T]()` intrinsic, so the caller supplies a placeholder.
+public func none[T](default: T) -> Optional[T] {
+    Optional { value: default, has_value: false }
 }
 
 // ── Query ────────────────────────────────────────────────────────────────────
 
-/// Returns `true` if a value is present.
-public func is_some[T](self: Optional[T]) -> bool {
-    return self.has_value;
+// Returns `true` if a value is present.
+public func is_some[T](opt: Optional[T]) -> bool {
+    opt.has_value
 }
 
-/// Returns `true` if no value is present.
-public func is_none[T](self: Optional[T]) -> bool {
-    return !self.has_value;
+// Returns `true` if no value is present.
+public func is_none[T](opt: Optional[T]) -> bool {
+    !opt.has_value
 }
 
 // ── Extraction ───────────────────────────────────────────────────────────────
 
-/// Returns the contained value. Panics if `self` is None.
-public func unwrap[T](self: Optional[T]) -> T {
-    if !self.has_value {
-        panic("Optional.unwrap: called on None");
+// Returns the contained value. Panics if `opt` is None.
+public func unwrap[T](opt: Optional[T]) -> T {
+    if !opt.has_value {
+        panic("Optional.unwrap: called on None")
     }
-    return self.value;
+    opt.value
 }
 
-/// Returns the contained value, or `default` if None.
-public func unwrap_or[T](self: Optional[T], default: T) -> T {
-    if self.has_value {
-        return self.value;
+// Returns the contained value, or `default` if None.
+public func unwrap_or[T](opt: Optional[T], default: T) -> T {
+    if opt.has_value {
+        opt.value
+    } else {
+        default
     }
-    return default;
 }
 
-/// Returns the contained value, or computes it from `f` if None.
-public func unwrap_or_else[T](self: Optional[T], f: func() -> T) -> T {
-    if self.has_value {
-        return self.value;
+// Returns the contained value. Panics with a custom message if None.
+public func expect[T](opt: Optional[T], msg: String) -> T {
+    if !opt.has_value {
+        panic(msg)
     }
-    return f();
+    opt.value
 }
 
-/// Returns the contained value. Panics with a custom message if None.
-public func expect[T](self: Optional[T], msg: String) -> T {
-    if !self.has_value {
-        panic(msg);
+// ── Combinators (no closures needed) ────────────────────────────────────────
+
+// Returns `other` if `opt` is Some; otherwise returns None (`default`
+// stands in for the unused payload, see `none[T]` above).
+public func and_opt[T, U](opt: Optional[T], other: Optional[U], default: U) -> Optional[U] {
+    if opt.has_value {
+        other
+    } else {
+        none[U](default)
     }
-    return self.value;
 }
 
-// ── Transformations ──────────────────────────────────────────────────────────
-
-/// Applies `f` to the contained value (if any), returning a new Optional.
-/// If None, returns None without calling `f`.
-public func map[T, U](self: Optional[T], f: func(T) -> U) -> Optional[U] {
-    if self.has_value {
-        return some(f(self.value));
+// Returns `opt` if it contains a value; otherwise returns `other`.
+public func or_opt[T](opt: Optional[T], other: Optional[T]) -> Optional[T] {
+    if opt.has_value {
+        opt
+    } else {
+        other
     }
-    return none[U]();
 }
 
-/// Applies `f` to the contained value (if any). `f` itself returns an Optional.
-/// This avoids double-wrapping: Optional[Optional[U]] -> Optional[U].
-public func and_then[T, U](self: Optional[T], f: func(T) -> Optional[U]) -> Optional[U] {
-    if self.has_value {
-        return f(self.value);
+// Returns `opt` if exactly one of `opt` and `other` is Some; otherwise None.
+public func xor_opt[T](opt: Optional[T], other: Optional[T], default: T) -> Optional[T] {
+    if opt.has_value && !other.has_value {
+        opt
+    } else if !opt.has_value && other.has_value {
+        other
+    } else {
+        none[T](default)
     }
-    return none[U]();
 }
 
-/// Returns `self` if it contains a value; otherwise evaluates and returns `f()`.
-public func or_else[T](self: Optional[T], f: func() -> Optional[T]) -> Optional[T] {
-    if self.has_value {
-        return self;
+// Flattens an Optional[Optional[T]] into Optional[T].
+public func flatten[T](opt: Optional[Optional[T]], default: T) -> Optional[T] {
+    if opt.has_value {
+        opt.value
+    } else {
+        none[T](default)
     }
-    return f();
 }
 
-/// Returns `other` if `self` is Some; otherwise returns None.
-public func and_opt[T, U](self: Optional[T], other: Optional[U]) -> Optional[U] {
-    if self.has_value {
-        return other;
-    }
-    return none[U]();
-}
-
-/// Returns `self` if it contains a value; otherwise returns `other`.
-public func or_opt[T](self: Optional[T], other: Optional[T]) -> Optional[T] {
-    if self.has_value {
-        return self;
-    }
-    return other;
-}
-
-/// Returns `self` if exactly one of `self` and `other` is Some; otherwise None.
-public func xor_opt[T](self: Optional[T], other: Optional[T]) -> Optional[T] {
-    if self.has_value && !other.has_value {
-        return self;
-    }
-    if !self.has_value && other.has_value {
-        return other;
-    }
-    return none[T]();
-}
-
-/// Flattens an Optional[Optional[T]] into Optional[T].
-public func flatten[T](self: Optional[Optional[T]]) -> Optional[T] {
-    if self.has_value {
-        return self.value;
-    }
-    return none[T]();
-}
-
-/// Returns None if the contained value does not satisfy `pred`.
-public func filter_opt[T](self: Optional[T], pred: func(T) -> bool) -> Optional[T] {
-    if self.has_value && pred(self.value) {
-        return self;
-    }
-    return none[T]();
-}
-
-/// Applies `f` to the value if present, returning `default` if absent.
-public func map_or[T, U](self: Optional[T], default: U, f: func(T) -> U) -> U {
-    if self.has_value {
-        return f(self.value);
-    }
-    return default;
-}
-
-/// Applies `f` to the value if present, or calls `default_fn` if absent.
-public func map_or_else[T, U](self: Optional[T], default_fn: func() -> U, f: func(T) -> U) -> U {
-    if self.has_value {
-        return f(self.value);
-    }
-    return default_fn();
-}
-
-/// Zips two Optionals into an Optional tuple. Returns Some only if both are Some.
-public func zip[T, U](a: Optional[T], b: Optional[U]) -> Optional[(T, U)] {
-    if a.has_value && b.has_value {
-        return some((a.value, b.value));
-    }
-    return none[(T, U)]();
-}
-
-/// Replaces the value inside the Optional with `new_value`, returning the old Optional.
-public func replace[T](self: Optional[T], new_value: T) -> (Optional[T], Optional[T]) {
-    let old = self;
-    let updated = some(new_value);
-    return (updated, old);
-}
-
-/// Takes the value out, leaving None in its place.
-public func take[T](self: Optional[T]) -> (Optional[T], Optional[T]) {
-    if self.has_value {
-        return (none[T](), self);
-    }
-    return (none[T](), none[T]());
-}
+// `replace`/`take` (returning both the updated Optional and the old one)
+// are omitted: they need a 2-tuple return type, and there is no anonymous
+// tuple *type* syntax in the current grammar to spell `(Optional[T],
+// Optional[T])` as a return type -- confirmed empirically (checked with
+// codira_syntax::SourceFile::parse: "expected type" right after the `->`).
+// `std/builtin/tuple.code` has a `Tuple` value type, but wiring a
+// two-result API through it is future work, not a same-session rename.

--- a/std/math/constants.code
+++ b/std/math/constants.code
@@ -1,141 +1,263 @@
-// std/math/constants.code
-// Mathematical constants for Codira.
-// All values are f64 (double precision IEEE 754).
+// =============================================================================
+// std/math/constants.code — Mathematical constants for Codira
+// =============================================================================
+// All values are f64 (double precision IEEE 754) unless noted otherwise.
+//
+// Migration note (2026-08-20): rewritten from `public let NAME: TYPE =
+// VALUE;` module-level bindings to `public func NAME() -> TYPE { VALUE }`
+// niladic functions, called as `PI()` rather than referenced as `PI`. This
+// is not a style preference -- verified empirically (via
+// codira_syntax::SourceFile::parse) that there is no top-level `let`/const
+// *item* in the current grammar at all: `codira_hir::item_tree::ModItem`
+// only has `Function`/`Struct`/`TypeAlias`/`Import`/`Impl` variants, and a
+// bare top-level `public let PI: f64 = ...;` fails to parse with "expected
+// a declaration" (`let`/`var` only exist as function-body statements, per
+// USING_CODIRA.md's "Bindings" section). A niladic function is the closest
+// honest Tier-1 equivalent -- it is a real, callable, constant-folding-
+// eligible function today, not a value binding.
+// =============================================================================
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Fundamental constants
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Pi — ratio of a circle's circumference to its diameter.
-public let PI: f64 = 3.14159265358979323846;
+// Pi — ratio of a circle's circumference to its diameter.
+public func PI() -> f64 {
+    3.14159265358979323846
+}
 
-/// Tau — 2 * pi (full turn in radians).
-public let TAU: f64 = 6.28318530717958647692;
+// Tau — 2 * pi (full turn in radians).
+public func TAU() -> f64 {
+    6.28318530717958647692
+}
 
-/// Euler's number — base of the natural logarithm.
-public let E: f64 = 2.71828182845904523536;
+// Euler's number — base of the natural logarithm.
+public func E() -> f64 {
+    2.71828182845904523536
+}
 
-/// Golden ratio phi = (1 + sqrt(5)) / 2.
-public let PHI: f64 = 1.61803398874989484820;
+// Golden ratio phi = (1 + sqrt(5)) / 2.
+public func PHI() -> f64 {
+    1.61803398874989484820
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Pi-derived fractions
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Pi / 2 — quarter turn.
-public let FRAC_PI_2: f64 = 1.57079632679489661923;
+// Pi / 2 — quarter turn.
+public func FRAC_PI_2() -> f64 {
+    1.57079632679489661923
+}
 
-/// Pi / 3.
-public let FRAC_PI_3: f64 = 1.04719755119659774615;
+// Pi / 3.
+public func FRAC_PI_3() -> f64 {
+    1.04719755119659774615
+}
 
-/// Pi / 4.
-public let FRAC_PI_4: f64 = 0.78539816339744830962;
+// Pi / 4.
+public func FRAC_PI_4() -> f64 {
+    0.78539816339744830962
+}
 
-/// Pi / 6.
-public let FRAC_PI_6: f64 = 0.52359877559829887308;
+// Pi / 6.
+public func FRAC_PI_6() -> f64 {
+    0.52359877559829887308
+}
 
-/// Pi / 8.
-public let FRAC_PI_8: f64 = 0.39269908169872415481;
+// Pi / 8.
+public func FRAC_PI_8() -> f64 {
+    0.39269908169872415481
+}
 
-/// 1 / Pi.
-public let FRAC_1_PI: f64 = 0.31830988618379067154;
+// 1 / Pi.
+public func FRAC_1_PI() -> f64 {
+    0.31830988618379067154
+}
 
-/// 2 / Pi.
-public let FRAC_2_PI: f64 = 0.63661977236758134308;
+// 2 / Pi.
+public func FRAC_2_PI() -> f64 {
+    0.63661977236758134308
+}
 
-/// 2 / sqrt(Pi).
-public let FRAC_2_SQRT_PI: f64 = 1.12837916709551257390;
+// 2 / sqrt(Pi).
+public func FRAC_2_SQRT_PI() -> f64 {
+    1.12837916709551257390
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Square roots
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Square root of 2.
-public let SQRT_2: f64 = 1.41421356237309504880;
+// Square root of 2.
+public func SQRT_2() -> f64 {
+    1.41421356237309504880
+}
 
-/// 1 / sqrt(2)  =  sqrt(2) / 2.
-public let FRAC_1_SQRT_2: f64 = 0.70710678118654752440;
+// 1 / sqrt(2)  =  sqrt(2) / 2.
+public func FRAC_1_SQRT_2() -> f64 {
+    0.70710678118654752440
+}
 
-/// Square root of 3.
-public let SQRT_3: f64 = 1.73205080756887729353;
+// Square root of 3.
+public func SQRT_3() -> f64 {
+    1.73205080756887729353
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Logarithmic constants
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Natural logarithm of 2.
-public let LN_2: f64 = 0.69314718055994530942;
+// Natural logarithm of 2.
+public func LN_2() -> f64 {
+    0.69314718055994530942
+}
 
-/// Natural logarithm of 10.
-public let LN_10: f64 = 2.30258509299404568402;
+// Natural logarithm of 10.
+public func LN_10() -> f64 {
+    2.30258509299404568402
+}
 
-/// Base-2 logarithm of e.
-public let LOG2_E: f64 = 1.44269504088896340736;
+// Base-2 logarithm of e.
+public func LOG2_E() -> f64 {
+    1.44269504088896340736
+}
 
-/// Base-10 logarithm of e.
-public let LOG10_E: f64 = 0.43429448190325182765;
+// Base-10 logarithm of e.
+public func LOG10_E() -> f64 {
+    0.43429448190325182765
+}
 
-/// Base-2 logarithm of 10.
-public let LOG2_10: f64 = 3.32192809488736234787;
+// Base-2 logarithm of 10.
+public func LOG2_10() -> f64 {
+    3.32192809488736234787
+}
 
-/// Base-10 logarithm of 2.
-public let LOG10_2: f64 = 0.30102999566398119521;
+// Base-10 logarithm of 2.
+public func LOG10_2() -> f64 {
+    0.30102999566398119521
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Special IEEE-754 values
 // ─────────────────────────────────────────────────────────────────────────────
+//
+// `__intrinsic_inf_f64`/`__intrinsic_nan_f64` are compiler-provided
+// intrinsics (design reference, matching the naming convention used
+// throughout std/builtin/dtype.code's `__intrinsic_*` calls) -- not
+// verified to resolve today; kept as the honest placeholder rather than a
+// fabricated numeric literal that would silently be wrong if IEEE bit
+// patterns for inf/nan ever changed.
 
-/// Positive infinity (f64).
-public let INF: f64 = __intrinsic_inf_f64();
+// Positive infinity (f64).
+public func INF() -> f64 {
+    __intrinsic_inf_f64()
+}
 
-/// Negative infinity (f64).
-public let NEG_INF: f64 = -__intrinsic_inf_f64();
+// Negative infinity (f64).
+public func NEG_INF() -> f64 {
+    -__intrinsic_inf_f64()
+}
 
-/// Not-a-Number (quiet NaN, f64).
-public let NAN: f64 = __intrinsic_nan_f64();
+// Not-a-Number (quiet NaN, f64).
+public func NAN() -> f64 {
+    __intrinsic_nan_f64()
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Machine epsilon and limits
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Smallest positive f64 such that  1.0 + EPSILON != 1.0.
-public let F64_EPSILON: f64 = 2.2204460492503131e-16;
+// Smallest positive f64 such that  1.0 + EPSILON != 1.0.
+public func F64_EPSILON() -> f64 {
+    2.2204460492503131e-16
+}
 
-/// Smallest positive normal f64.
-public let F64_MIN_POSITIVE: f64 = 2.2250738585072014e-308;
+// Smallest positive normal f64.
+public func F64_MIN_POSITIVE() -> f64 {
+    2.2250738585072014e-308
+}
 
-/// Largest finite f64.
-public let F64_MAX: f64 = 1.7976931348623157e+308;
+// Largest finite f64.
+public func F64_MAX() -> f64 {
+    1.7976931348623157e+308
+}
 
-/// Smallest positive f32 such that 1.0 + EPSILON != 1.0.
-public let F32_EPSILON: f32 = 1.1920929e-7;
+// Smallest positive f32 such that 1.0 + EPSILON != 1.0.
+public func F32_EPSILON() -> f32 {
+    1.1920929e-7
+}
 
-/// Smallest positive normal f32.
-public let F32_MIN_POSITIVE: f32 = 1.17549435e-38;
+// Smallest positive normal f32.
+public func F32_MIN_POSITIVE() -> f32 {
+    1.17549435e-38
+}
 
-/// Largest finite f32.
-public let F32_MAX: f32 = 3.40282347e+38;
+// Largest finite f32.
+public func F32_MAX() -> f32 {
+    3.40282347e+38
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Integer limits
 // ─────────────────────────────────────────────────────────────────────────────
 
-public let I8_MIN:   i8   = -128;
-public let I8_MAX:   i8   = 127;
-public let U8_MAX:   u8   = 255;
+public func I8_MIN() -> i8 {
+    -128
+}
 
-public let I16_MIN:  i16  = -32768;
-public let I16_MAX:  i16  = 32767;
-public let U16_MAX:  u16  = 65535;
+public func I8_MAX() -> i8 {
+    127
+}
 
-public let I32_MIN:  i32  = -2147483648;
-public let I32_MAX:  i32  = 2147483647;
-public let U32_MAX:  u32  = 4294967295;
+public func U8_MAX() -> u8 {
+    255
+}
 
-public let I64_MIN:  i64  = -9223372036854775808;
-public let I64_MAX:  i64  = 9223372036854775807;
-public let U64_MAX:  u64  = 18446744073709551615;
+public func I16_MIN() -> i16 {
+    -32768
+}
 
-public let I128_MIN: i128 = -170141183460469231731687303715884105728;
-public let I128_MAX: i128 = 170141183460469231731687303715884105727;
-public let U128_MAX: u128 = 340282366920938463463374607431768211455;
+public func I16_MAX() -> i16 {
+    32767
+}
+
+public func U16_MAX() -> u16 {
+    65535
+}
+
+public func I32_MIN() -> i32 {
+    -2147483648
+}
+
+public func I32_MAX() -> i32 {
+    2147483647
+}
+
+public func U32_MAX() -> u32 {
+    4294967295
+}
+
+public func I64_MIN() -> i64 {
+    -9223372036854775808
+}
+
+public func I64_MAX() -> i64 {
+    9223372036854775807
+}
+
+public func U64_MAX() -> u64 {
+    18446744073709551615
+}
+
+public func I128_MIN() -> i128 {
+    -170141183460469231731687303715884105728
+}
+
+public func I128_MAX() -> i128 {
+    170141183460469231731687303715884105727
+}
+
+public func U128_MAX() -> u128 {
+    340282366920938463463374607431768211455
+}


### PR DESCRIPTION
Introduce a parametric mid-level IR and compile-time evaluator: add new crates codira_mir and codira_comptime (IR, generator, ops, interpreter, tests). Wire a restricted comptime-fold into codira_hir (folding/lowering, generic-param tracking, pretty-printing and tests). Add helper example/tooling (codira_syntax check_file) and many std migrations to the new syntax. Add agent-facing docs (USING_CODIRA, EMBEDDING_CODIRA, RUST_TO_CODIRA_MIGRATION). Update codira_lld/LLVM deps and refresh Cargo.lock (dependency bumps and new workspace packages).